### PR TITLE
Delete islands no longer in a thread

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Events.sk
+++ b/SkyBlock/SKYBLOCK.SK/Events.sk
@@ -209,7 +209,6 @@ on script load:
 		set {_loc::3} to {_loc::3} parsed as number
 		set {_bedrock} to location at {_loc::1}, {_loc::2}, {_loc::3} in "%{SB::config::world}%" parsed as world
 		if block at {_bedrock} is air:
-			message "old island detected"
 			delete {SB::islvl::%loop-index%}
 			delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::leader}
 			delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::level}

--- a/SkyBlock/SKYBLOCK.SK/Events.sk
+++ b/SkyBlock/SKYBLOCK.SK/Events.sk
@@ -199,6 +199,24 @@ on script load:
 		delete {deleteisland.2::%loop-index%}
 	delete {SB::ISDELPROCESS}
 	#
+	# > If we're done with deleting islands, also double check there is not a level entry left.
+	# > If there is one left, delete it and delete all variables to the island.
+	#
+	loop {SB::islvl::*}:
+		set {_loc::*} to loop-index split at "_"
+		set {_loc::1} to {_loc::1} parsed as number
+		set {_loc::2} to {_loc::2} parsed as number
+		set {_loc::3} to {_loc::3} parsed as number
+		set {_bedrock} to location at {_loc::1}, {_loc::2}, {_loc::3} in "%{SB::config::world}%" parsed as world
+		if block at {_bedrock} is air:
+			message "old island detected"
+			delete {SB::islvl::%loop-index%}
+			delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::leader}
+			delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::level}
+			delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::exp}
+			delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::created}
+
+	#
 	# > If we're done, allow players back on the server by disabling the whitelist.
 	#
 	execute console command "/whitelist off"

--- a/SkyBlock/SKYBLOCK.SK/Events.sk
+++ b/SkyBlock/SKYBLOCK.SK/Events.sk
@@ -154,19 +154,35 @@ on explode:
 	cancel event
 
 #Island removal process at startup:
+# > Event: on script load
+# > Actions:
+# > This is loaded once the skript is loaded, it deletes some variables which aren't needed anymore
+# > and also goes trough islands which should be deleted, all island locations are saved within
+# > the {deleteisland.1::*} and {deleteisland.2::*} array.
 on script load:
 	set {SB::searchprocess} to false
 	delete {SB::searchis::*}
 	delete {SB::hunger::*}
 	delete {SB::calcstatus::*}
 	delete {SB::actionload::*}
-
-	$ thread
+	
+	#
+	# > Loop trough all islands which should be deleted
+	#
 	loop {deleteisland.1::*}:
+		#
+		# > Wait a short time to give the server some break
+		#
 		wait 0.5 seconds
+		#
+		# > Set the local variables {_loc1} and {_loc2} to the two borders of the island
+		#
 		set {_loc1} to loop-value
-		set {_loc2} to {Deleteisland.2::%loop-index%}
+		set {_loc2} to {deleteisland.2::%loop-index%}
 
+		#
+		# > Go trough all the blocks within the two borders and remove them.
+		#
 		loop blocks within {_loc1} to {_loc2}:
 			if loop-block is chest or trapped chest:
 				clear loop-block's inventory
@@ -176,10 +192,16 @@ on script load:
 			if {_i} is 500:
 				wait 1 tick
 				delete {_i}
+		#
+		# > Delete the array entry, we're completed with the code above:
+		#
 		delete {deleteisland.1::%loop-index%}
 		delete {deleteisland.2::%loop-index%}
 	delete {SB::ISDELPROCESS}
-	execute console command "/whitelist on"
+	#
+	# > If we're done, allow players back on the server by disabling the whitelist.
+	#
+	execute console command "/whitelist off"
 
 on script unload:
 	execute console command "/whitelist on"

--- a/SkyBlock/SKYBLOCK.SK/Functions.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions.sk
@@ -475,3 +475,80 @@ function searchbedrock(p:player) :: location:
 			#
 			set {_loc} to location at 5, -5, 5 in "%{SB::config::world}%" parsed as world
 			return {_loc}
+
+#
+# > Import of all necessary classes for the loadislandstoworld function
+#
+import:
+	java.io.File
+	java.io.FileInputStream
+	java.io.FileOutputStream
+
+# > Function - loadislandstoworld:
+# > Arguments:
+# > none
+# > Actions:
+# > Once the configuration file is loaded, this function is executed.
+# > This function loads ".nbt" files from the "plugins/Skript/scripts/SkyBlock/islands" folder
+# > into the defined world folder.
+function loadislandstoworld():
+	#
+	# > Get a list all files in the folder of the "plugins/Skript/scripts/SkyBlock/islands" folder
+	#
+	set {_files::*} to ...new File("plugins/Skript/scripts/SkyBlock/islands").listFiles()
+	#
+	# > Loop trough all the files
+	#
+	loop {_files::*}:
+		#
+		# > If the loop-value (file) ends with ".nbt", it should continue
+		#
+		set {_check} to loop-value.toString().endsWith(".nbt")
+		if {_check} is true:
+			#
+			# > Prints to console that it tries to copy import the files.
+			#
+			send "[SkyBlock] > Try to import %{_fname}% into your world..." to console
+			#
+			# > Get the name of the loop file.
+			#
+			set {_fname} to loop-value.getName()
+			#
+			# > Look if there is already a file with that name
+			#
+			set {_checkfile} to new File("%{SB::config::world}%/generated/minecraft/structures/%{_fname}%")
+			if {_checkfile}.isFile() is true:
+				#
+				# > Print that there is already a file with this name
+				#
+				send "[SkyBlock] > %{_fname}% is already set." to console
+			else:
+				#
+				# > There is no file with that name, copy it.
+				# > Set the {_source} to the loop file (our source)
+				#
+				set {_source} to loop-value
+				#
+				# > Set the {_dest} to our destination, which we already used with {_checckfile} above
+				#
+				set {_dest} to {_checkfile}
+				#
+				# > Set both stream channels to null
+				#
+				set {_sourceChannel} to null
+				set {_destChannel} to null
+				#
+				# > Open a new input and output stream to copy the files using transferFrom
+				#
+				set {_sourceChannel} to new FileInputStream({_source}).getChannel()
+				set {_destChannel} to new FileOutputStream({_dest}).getChannel()
+				#
+				# > Copy the file from the {_sourceChannel} to the {_destChannel}
+				#
+				{_destChannel}.transferFrom({_sourceChannel}, 0, {_sourceChannel}.size())
+				#
+				# > Close both streams and print a success message to console
+				#
+				{_sourceChannel}.close()
+				{_destChannel}.close()
+				send "[SkyBlock] > Successfully imported %{_fname}%!" to console

--- a/SkyBlock/SKYBLOCK.SK/Functions.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions.sk
@@ -151,16 +151,24 @@ function checkprotect(l:location,p:player) :: text:
 		return {_r}
 	else:
 		return "true"
-
-#Prints message to player
+#
+# > Function: protectionmgs
+# > Actions:
+# > Prints a error message to the player that this area is protected.
+#
 function protectionmgs(p:player):
 	set {_uuid} to uuid of {_p}
 	set {_prefix} to {SB::lang::prefix::%{SK::lang::%{_uuid}%}%}
 	set {_a} to {SB::lang::protect::%{SK::lang::%{_uuid}%}%}
-	message "%{_prefix}% %{_a}%" to {_p}
-	#todo change this into a action bar to prevent spam: execute console command "/title %{_p}% actionbar {""text"":""%{_prefix}% %{_a}%""}"
+	actionload({_p}, {_a})
 
-#Prints tellraw message to player, on which the player can click and execute a command
+#
+# > Function: tellrawmsg1
+# > Arguments:
+# > <player>player, <text>text, <text>clickable text, <text>command
+# > Actions:
+# > Sends the player a clickable text message which executes a command on click.
+#
 function tellrawmsg1(p:player,t1:text,t2:text,c:text):
 	execute console command "/tellraw %{_p}% ["""",{""text"":""%{_t1}% ""},{""text"":""%{_t2}%"",""clickEvent"":{""action"":""run_command"",""value"":""%{_c}%""}}]"
 

--- a/SkyBlock/SKYBLOCK.SK/Functions.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions.sk
@@ -24,8 +24,14 @@ function leaveisland(p:player, text:text):
 				set {_i} to loop-index
 				delete {SB::island::%{_locx}%_%{_locy}%_%{_locz}%::member::%{_i}%}
 				stop loop
-				
-#Calculate the island level - executed in a thread
+#				
+# > Function: calcisland
+# > Arguments:
+# > <player>player
+# > Actions:
+# > Calculates the island level by getting both borders on the island, then looping though all blocks and
+# > calculating all predefined experience bonuses from the configuration together to get a level.
+#
 function calcisland(p:player):
 	set {_exp} to 0 
 	set {_level} to 1
@@ -217,7 +223,7 @@ function deleteisland(p1: player):
 		delete {Islanddelete.%{_p1}%}
 	else:
 		set {_a} to {SB::lang::notallowed::%{Language::%{_p1}%}%}
-		message "%{_prefix}% %{_a}%" to {_p1}
+		actionload({_p1}, {_a})
 
 #Loading bar in actionbar and result
 function actionload(p: player, t:text):

--- a/SkyBlock/addons/elevator.sk
+++ b/SkyBlock/addons/elevator.sk
@@ -11,7 +11,8 @@
 # ==============
 # How to use it:
 # ==============
-# > This skript doesn't need any setup on server side.
+# > This skript doesn't need any special setup on server side.
+# > First use: Place elevator.sk into your "plugins/Skript/scripts/" folder and restart. Subfolders are possible too.
 # > Steps for users:
 # > 1: Place a sign on the bottom with the following contents:
 # > =Line 1: [Lift]

--- a/SkyBlock/addons/elevator.sk
+++ b/SkyBlock/addons/elevator.sk
@@ -26,6 +26,7 @@
 # > Custom can replaced by players like they want to help orientation.
 # > The lift signs have to be on the same x and y axis to work.
 # ==============
+
 #
 # > The following options change the look of the skript
 #

--- a/SkyBlock/addons/elevator.sk
+++ b/SkyBlock/addons/elevator.sk
@@ -57,14 +57,30 @@ on rightclick on sign:
 	if line 1 of event-block is {@sign_lift}:
 		set {_loc::1} to location of event-block
 		set {_loc::2} to {_loc::1}
+		#
+		# > If the event-block has the down content, set y-coordinate to 0
+		# > and remove 1 from the y-coordinate of the clicked block.
+		#
 		if line 2 of event-block is {@sign_down}:
 			set y-coordinate of {_loc::1} to 0
 			remove 1 from y-coordinate of {_loc::2}
+		#
+		# > If the event-block has the up content, set y-coordinate to 256
+		# > and add 1 to the y-coordinate of the clicked block.
+		#
 		else if line 2 of event-block is {@sign_up}:
 			set y-coordinate of {_loc::1} to 256
 			add 1 to y-coordinate of {_loc::2}
+		#
+		# > If the event-block has not either "Up" or "Down", stop here.
+		#
 		else:
 			stop
+		#
+		# > Loop trough all blocks between the elevator sign and the possible other elevator sign,
+		# > if found, it takes the difference between the clicked elevator and the found elevator and
+		# > changes the y-coordinate of the players location by this difference and then teleports the player.
+		#
 		loop blocks within {_loc::1} to {_loc::2}:
 			if loop-block is sign:
 				if line 1 of loop-block is {@sign_lift}:
@@ -75,6 +91,20 @@ on rightclick on sign:
 					else if line 2 of event-block is {@sign_up}:
 						set {_diff} to difference between y-coordinate of event-block and y-coordinate of loop-block
 						add {_diff} to y-coordinate of {_ploc}
+					#
+					# > If the block below the new player location is air, try to add 0.5 blocks to
+					# > make this save.
+					#
+					if the block below {_ploc} is air:
+						add 0.5 to y-coordinate of {_ploc}
+					#
+					# > If it is not save to stay on the now location now, stop here.
+					#
+					if the block below {_ploc} is air:
+						stop
+					#
+					# > It should be save to teleport the player to the new location now.
+					#
 					teleport player to {_ploc}
 
 #

--- a/SkyBlock/addons/elevator.sk
+++ b/SkyBlock/addons/elevator.sk
@@ -1,0 +1,93 @@
+#
+# ==============
+# elevator.sk v0.0.1
+# ==============
+# Let users build elevators using signs
+# ==============
+# Dependencies
+# ==============
+# > Spigot 1.13.2 - https://hub.spigotmc.org/jenkins/job/BuildTools/
+# > Skript by bensku - https://github.com/SkriptLang/Skript/releases
+# ==============
+# How to use it:
+# ==============
+# > This skript doesn't need any setup on server side.
+# > Steps for users:
+# > 1: Place a sign on the bottom with the following contents:
+# > =Line 1: [Lift]
+# > =Line 2: Up
+# > =Line 3: Custom
+# > =Line 4: Custom
+# > 2: Place a sign on the top with the following contents:
+# > =Line 1: [Lift]
+# > =Line 2: Down
+# > =Line 3: Custom
+# > =Line 4: Custom
+# > Custom can replaced by players like they want to help orientation.
+# > The lift signs have to be on the same x and y axis to work.
+# ==============
+#
+# > The following options change the look of the skript
+#
+options:
+	#
+	# > Defines how the "Down" sign should look like:
+	#
+	sign_down: "↓ DOWN ↓"
+	#
+	# > Defines how the "Up" sign should look like:
+	#
+	sign_up: "↑ UP ↑"
+	#
+	# > Defines how the 1st line of the elevator sign should look like:
+	#
+	sign_lift: "&l[LIFT]"
+
+#
+# > Event - on rightclick on a sign
+# > Actions:
+# > This event gets triggered if someone rightclicks on a sign, then it is checked if
+# > the clicked block (event-block) is a elevator by checking the {@sign_lift} option.
+# > If it is a elevator, check if its going up or down and then go trough all blocks,
+# > below the sign or above, depending if it is going up or down.
+# > Then change the y-coordinate of the player to the difference between the two signs.
+#
+on rightclick on sign:
+	if line 1 of event-block is {@sign_lift}:
+		set {_loc::1} to location of event-block
+		set {_loc::2} to {_loc::1}
+		if line 2 of event-block is {@sign_down}:
+			set y-coordinate of {_loc::1} to 0
+			remove 1 from y-coordinate of {_loc::2}
+		else if line 2 of event-block is {@sign_up}:
+			set y-coordinate of {_loc::1} to 256
+			add 1 to y-coordinate of {_loc::2}
+		else:
+			stop
+		loop blocks within {_loc::1} to {_loc::2}:
+			if loop-block is sign:
+				if line 1 of loop-block is {@sign_lift}:
+					set {_ploc} to location of player
+					if line 2 of event-block is {@sign_down}:
+						set {_diff} to difference between y-coordinate of event-block and y-coordinate of loop-block
+						remove {_diff} from y-coordinate of {_ploc}
+					else if line 2 of event-block is {@sign_up}:
+						set {_diff} to difference between y-coordinate of event-block and y-coordinate of loop-block
+						add {_diff} to y-coordinate of {_ploc}
+					teleport player to {_ploc}
+
+#
+# > Event - on sign change
+# > Actions:
+# > Once a sign is changed, this trigger is going to check if the first line of the
+# > changed sign has "[Lift]" as first line and "Up" or "Down" on the second line, if so,
+# > it is going to format the sign into the right format like defined in the options. 
+#
+on sign change:
+	if line 1 of event-block is "[Lift]":
+		if line 2 of event-block is "Up" or "Down":
+			set line 1 of event-block to {@sign_lift}
+			if line 2 of event-block is "Down":
+				set line 2 of event-block to {@sign_down}
+			if line 2 of event-block is "Up":
+				set line 2 of event-block to {@sign_up}

--- a/SkyBlock/config.sk
+++ b/SkyBlock/config.sk
@@ -197,3 +197,8 @@ on load:
 	add diorite to {SB::oregen::*}
 	add 100 to {SB::oregenc::*}
 	add stone to {SB::oregen::*}
+
+#
+# > Functions to start after config loaded, do not change this if you don't know what you're doing.
+#
+	loadislandstoworld()


### PR DESCRIPTION
- Delete islands no longer using a thread, since this is not working. This has to be in the main thread and takes some time, but this only happens on the server startup and shouldn't be a problem.
- Also, it could be a solution to check options available in the java api, how is worldedit doing these big worldedit changes without lag?
- Set the whitelist off once the island delete process is done