### PR TITLE
Use included Java classes instead of console commands

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Functions/actionbar.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/actionbar.sk
@@ -5,7 +5,13 @@
 # actionbar.sk is part of the SKYBLOCK.SK functions.
 # ==============
 
-#Loading bar in actionbar and result
+#
+# > Function: actionload
+# > Arguments:
+# > <player>player, <text>text
+# > Actions:
+# > Creates a endless loading bar which stops once the function is
+# > called with text. Call it with "start" to start the loading bar.
 function actionload(p: player, t:text):
 	if {_t} is "start":
 		set {SB::actionload::%{_p}%} to 1
@@ -13,11 +19,11 @@ function actionload(p: player, t:text):
 		while {SB::actionload::%{_p}%} is set:
 			if {_vs} is "&6█&7█████████": 
 				set {_s} to "&7[&r%{_vs}%&7]&r" 
-				execute console command "/title %{_p}% actionbar {""text"":""%{_vs}%""}"
+				actionbar({_p},{_vs})
 				wait 0.2 seconds
 			replace all "&6█&7█" with "&7█&6█&7" in {_vs}
 			set {_s} to "&7[&r%{_vs}%&7]&r" 
-			execute console command "/title %{_p}% actionbar {""text"":""%{_vs}%""}"
+			actionbar({_p},{_vs})
 			if {_vs} is "&7█&7█&7█&7█&7█&7█&7█&7█&7█&6█&7":
 				set {_vs} to "&6█&7█████████"
 			wait 0.2 seconds
@@ -26,6 +32,30 @@ function actionload(p: player, t:text):
 		set {_s} to "&6█████████&r %{_t}% &6█████████"
 		loop 8 times:
 			replace all "&6██" with "&6█" in {_s}
-			execute console command "/title %{_p}% actionbar {""text"":""%{_s}%""}"
+			actionbar({_p},{_s})
 			wait 10 ticks
-		execute console command "/title %{_p}% actionbar {""text"":""""}"
+		actionbar({_p},"")
+
+#
+# > Import Java classes for the actionbar function.
+import:
+	net.md_5.bungee.api.ChatMessageType
+	net.md_5.bungee.api.chat.TextComponent	
+
+#
+# > Function: actionbar
+# > Arguments:
+# > <player>player, <text>text
+# > Actions:
+# > Displays the actionbar to the player trough the bungee api, which is
+# > also available in Spigot without BungeeCord.
+function actionbar(p: player, t:text):
+	#
+	# > Set the text parameter to a TextComponent.
+	set {_tc} to new TextComponent({_t})
+	#
+	# > Set the chat message type to action bar.
+	set {_cmt} to ChatMessageType.ACTION_BAR!
+	#
+	# > Send the message to the player.
+	{_p}.spigot().sendMessage({_cmt}, {_tc})


### PR DESCRIPTION
This replaces a bad code practice, since ```execute console command "/title %player% actionbar {""text"":""text that should appear here""}"``` is not the direct way. The new way is the right way of how it should be done.