### PR TITLE
Added progressing loading bar to calcisland function

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Commands.sk
+++ b/SkyBlock/SKYBLOCK.SK/Commands.sk
@@ -347,7 +347,6 @@ command /island [<text>] [<text=1>] [<text>]:
 			else:
 				set {SB::calcdown::%uuid of player%} to now
 				set {SB::calcstatus::%player%} to 1
-				make player execute "/is calcwait"
 				$ thread
 				calcisland(player)
 		else if arg-1 is "calcwait":


### PR DESCRIPTION
Before, there were only a loading bar which had no progress and only visualized that the function has work but not the progress itself. This is changed with this pull request, which also solves this issue: https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/31