### PR TITLE
Changed tabs to spaces, /island info now uses checkislandaccess

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Commands.sk
+++ b/SkyBlock/SKYBLOCK.SK/Commands.sk
@@ -4,782 +4,791 @@
 # > This command contains multible of actions which are meant to be used by an administrator for
 # > administration and moderation purposes.
 command /islandadmin [<text>] [<text>] [<text>] [<text>] [<text>]:
-	permission:	is.admin
-	aliases: /isadmin
-	trigger:
-		#
-		# > Set prefix for messages
-		set {_prefix} to {SB::lang::prefix::%{SK::lang::%uuid of player%}%}
-		#
-		# > Argument: "go" ("home" OR "tp")
-		# > Teleports the user to the defined player
-		# > Actions:
-		# > Teleports the player to the defined player island
-		if arg-1 is "go" OR "home" OR "tp":
-			set {_player} to arg-2 parsed as offline player
-			set {_uuid} to uuid of {_player}
-			homehandler({_player},"home",arg-3,player)
-			stop
-		#
-		# > If something should be done with an island, this is the code:
-		else if arg-1 is "island":
-			#
-			# > Argument: "calc"
-			# > If the user types in /islandadmin island calc, the island level gets calculated
-			# > Actions:
-			# > Checks if the defined user has a island and then run the calcisland function.
-			if arg-2 is "calc":
-				set {_player} to arg-3 parsed as offline player
-				set {_uuid} to uuid of {_player}
-				if {SB::player::%{_uuid}%::island::bedrock} is set:
-					message "%{_prefix}% %{SB::lang::isadmin::fcalc::%{SK::lang::%uuid of player%}%}%"
-					$ thread
-					calcisland({_player})
+  permission:  is.admin
+  aliases: /isadmin
+  trigger:
+    #
+    # > Set prefix for messages
+    set {_prefix} to {SB::lang::prefix::%{SK::lang::%uuid of player%}%}
+    #
+    # > Argument: "go" ("home" OR "tp")
+    # > Teleports the user to the defined player
+    # > Actions:
+    # > Teleports the player to the defined player island
+    if arg-1 is "go" OR "home" OR "tp":
+      set {_player} to arg-2 parsed as offline player
+      set {_uuid} to uuid of {_player}
+      homehandler({_player},"home",arg-3,player)
+      stop
+    #
+    # > If something should be done with an island, this is the code:
+    else if arg-1 is "island":
+      #
+      # > Argument: "calc"
+      # > If the user types in /islandadmin island calc, the island level gets calculated
+      # > Actions:
+      # > Checks if the defined user has a island and then run the calcisland function.
+      if arg-2 is "calc":
+        set {_player} to arg-3 parsed as offline player
+        set {_uuid} to uuid of {_player}
+        if {SB::player::%{_uuid}%::island::bedrock} is set:
+          message "%{_prefix}% %{SB::lang::isadmin::fcalc::%{SK::lang::%uuid of player%}%}%"
+          $ thread
+          calcisland({_player})
 
-			#
-			# > Argument: "purge"
-			# > If the user types in /islandadmin island purge <number>, islands, which have been inactive for the defined
-			# > number of days are going to be deleted. This is dangerous and a backup should be made prior entering this.
-			# > Actions:
-			# > Deleted all islands which have been inactive for more than x days.
-			if arg-2 is "purge":
-				if arg-3 is not set:
-					stop
-				#
-				# > Calls purgeislands function, this shortens the size of this file.
-				purgeislands(player,arg-3,arg-4)
-				
-			if arg-2 is "delete":
-				#
-				# > Calls the admintool-deleteisland function, which is going to handle island deletation by admins.
-				admintools_deleteisland(player,arg-3,arg-4)
+      #
+      # > Argument: "purge"
+      # > If the user types in /islandadmin island purge <number>, islands, which have been inactive for the defined
+      # > number of days are going to be deleted. This is dangerous and a backup should be made prior entering this.
+      # > Actions:
+      # > Deleted all islands which have been inactive for more than x days.
+      if arg-2 is "purge":
+        if arg-3 is not set:
+          stop
+        #
+        # > Calls purgeislands function, this shortens the size of this file.
+        purgeislands(player,arg-3,arg-4)
+        
+      if arg-2 is "delete":
+        #
+        # > Calls the admintool-deleteisland function, which is going to handle island deletation by admins.
+        admintools_deleteisland(player,arg-3,arg-4)
 
-			#
-			# > Argument: "addmember"
-			# > If the user types in /islandadmin island addmember <player>, the defined player is added to the island.
-			# > Actions:
-			# > Adds the player to the island the executor is standing on.
-			if arg-2 is "addmember":
-				admintools_addmember(player,arg-3)
-				
-			#
-			# > Argument: "kickall"
-			# > If the user types in /islandadmin island kickall, all players of the current island are kicked.
-			# > Actions:
-			# > Kicks everyone on the island the player is currently at without deleting it using the admintools_kickall function.
-			if arg-2 is "kickall":
-				admintools_kickall(player,arg-3,arg-4)
+      #
+      # > Argument: "addmember"
+      # > If the user types in /islandadmin island addmember <player>, the defined player is added to the island.
+      # > Actions:
+      # > Adds the player to the island the executor is standing on.
+      if arg-2 is "addmember":
+        admintools_addmember(player,arg-3)
+        
+      #
+      # > Argument: "kickall"
+      # > If the user types in /islandadmin island kickall, all players of the current island are kicked.
+      # > Actions:
+      # > Kicks everyone on the island the player is currently at without deleting it using the admintools_kickall function.
+      if arg-2 is "kickall":
+        admintools_kickall(player,arg-3,arg-4)
 
-			#
-			# > Argument: "changebiome"
-			# > If the user types in /islandadmin island changebiome <biome>, the biome of the current island is changed.
-			# > Optional: Define the owner of the island to take it instead of the current island.
-			# > Actions:
-			# > Changes the biome of the island the user is standing on or the defined 4nd argument.
-			if arg-2 is "changebiome":
-				admintools_changebiome(player,arg-3,arg-4)
-	
-			#
-			# > Argument: "changeleader"
-			# > If the user types in /islandadmin island changeleader <new leader>, the leader is changed to this player on which the admin
-			# > is currently standing on, works only, if there is already a leader and a member in the island.
-			# > Actions:
-			# > Changes the leader using the admintools_changeleader function.
-			if arg-2 is "changeleader":
-				admintools_changeleader(player,arg-3,arg-4,arg-5)
+      #
+      # > Argument: "changebiome"
+      # > If the user types in /islandadmin island changebiome <biome>, the biome of the current island is changed.
+      # > Optional: Define the owner of the island to take it instead of the current island.
+      # > Actions:
+      # > Changes the biome of the island the user is standing on or the defined 4nd argument.
+      if arg-2 is "changebiome":
+        admintools_changebiome(player,arg-3,arg-4)
+  
+      #
+      # > Argument: "changeleader"
+      # > If the user types in /islandadmin island changeleader <new leader>, the leader is changed to this player on which the admin
+      # > is currently standing on, works only, if there is already a leader and a member in the island.
+      # > Actions:
+      # > Changes the leader using the admintools_changeleader function.
+      if arg-2 is "changeleader":
+        admintools_changeleader(player,arg-3,arg-4,arg-5)
 
-			#
-			# > Argument: "invite"
-			# > Invites a player for the owner of the island
-			# > Actions:
-			# > This is going to invite a player, like it would have been done by the owner directly.
-			# > Use addmember to add a member without asking the user.
-			if arg-2 is "invite":
-				admintools_invite(player,arg-3,arg-4)
+      #
+      # > Argument: "invite"
+      # > Invites a player for the owner of the island
+      # > Actions:
+      # > This is going to invite a player, like it would have been done by the owner directly.
+      # > Use addmember to add a member without asking the user.
+      if arg-2 is "invite":
+        admintools_invite(player,arg-3,arg-4)
 
-			#
-			# > Argument: "create"
-			# > Invites a player for the owner of the island
-			# > Actions:
-			# > This argument calls the admintools_create function, which creates a new island at the location
-			# > of the player, if available.
-			if arg-2 is "create":
-				admintools_create(player)
+      #
+      # > Argument: "create"
+      # > Invites a player for the owner of the island
+      # > Actions:
+      # > This argument calls the admintools_create function, which creates a new island at the location
+      # > of the player, if available.
+      if arg-2 is "create":
+        admintools_create(player)
 
-		#
-		# > If no argument has been used, tell the player what is possible:
-		else:
-			message "/isadmin island invite <Owner> <New Player> - Invite player to the island"
-			message "/isadmin island changeleader <New Owner> - Change the leader of the island on which you're standing to the new owner (has to be a member)"
-			message "/isadmin island changebiome <new biome> [<Owner>] - Changes the biome for the island you're standing on or the defined owner"
-			message "/isadmin island kickall - kicks everyone from the island you're standing on"
-			message "/isadmin island delete <player> - Deletes the island of the player"
-			message "/isadmin island addmember <player> - adds the defined player to the island you're currently at, if no leader is set, the player gets the leader"
-			message "/isadmin island calc <player> - calculates the island of the defined player"
-	
+    #
+    # > If no argument has been used, tell the player what is possible:
+    else:
+      message "/isadmin island invite <Owner> <New Player> - Invite player to the island"
+      message "/isadmin island changeleader <New Owner> - Change the leader of the island on which you're standing to the new owner (has to be a member)"
+      message "/isadmin island changebiome <new biome> [<Owner>] - Changes the biome for the island you're standing on or the defined owner"
+      message "/isadmin island kickall - kicks everyone from the island you're standing on"
+      message "/isadmin island delete <player> - Deletes the island of the player"
+      message "/isadmin island addmember <player> - adds the defined player to the island you're currently at, if no leader is set, the player gets the leader"
+      message "/isadmin island calc <player> - calculates the island of the defined player"
+  
 command /island [<text>] [<text=1>] [<text>]:
-	aliases: /is, /sb, /skyblock
-	trigger:
-		set {_prefix} to {SB::lang::prefix::%{SK::lang::%uuid of player%}%}
-		if arg-1 is not set:
-			skyblockgui(player)
-		if arg-1 is "reload":
-			if player has permission "%{SB::config::buildpermission}%":
-				make player execute "/sk reload SkyBlock/"
-		if arg-1 is "create":
-			if {SB::player::%uuid of player%::island::bedrock} is set:
-				message "%{_prefix}% %{SB::lang::alreadyis::%{SK::lang::%uuid of player%}%}%"
-				stop
-			#
-			# > If we're already searching for an island for the player, print information and stop.
-			if {SB::searchis::%player%} is set:
-				message "%{_prefix}% %{SB::lang::waitis::%{SK::lang::%uuid of player%}%}%"
-				stop
-			if player is online:
-				if arg-2 is "1":
-					opengui(player,9,"%{SB::lang::islands::%{SK::lang::%uuid of player%}%}%")
-					set {_s} to 0
-					# 
-					# > Go trough all available schematics or structures, which where set in the config.sk and display it in the islands gui.
-					loop {SB::schematics::schematic::*}:
-						set {_item} to grass named "%{SB::schematics::name::%{SK::lang::%uuid of player%}%::%loop-index%}%"
-						setguiitem(player,{_s},"grass",1,"%{SB::schematics::name::%{SK::lang::%uuid of player%}%::%loop-index%}%","","make ""%player%"" parsed as player execute ""/is create %loop-value%""",false)
-						add 1 to {_s}
-					delete {_s}
-					delete {_Bla::*}
-					stop
-				else:
-					#check, if defined schematic exists:
-					if {SB::config::isstorage} is "Schematic":
-						if file "plugins/WorldEdit/schematics/%arg-2%" exists:
-							#security check, is this schematic within the config:
-							set {_ok} to false
-							loop {SB::schematics::schematic::*}:
-								if loop-value is arg-2:
-									set {_ok} to true
-							#not found, print error and stop:
-							if {_ok} is "false":
-								send "&c&lError"
-								stop
-						#file doesnt exist, print error and stop:
-						else:
-							send "&c&lError"
-							stop
-					#if there is no schematic, don't do anything for now
-					else:
-						set {_ok} to true
-			actionload(player,"start")
-			while {SB::searchprocess} is true:
-				wait 10 ticks
-			if {SB::searchis::%player%} is set:
-				message "%{_prefix}% %{SB::lang::waitis::%{SK::lang::%uuid of player%}%}%"
-				stop
-			else:
-				set {SB::searchis::%player%} to true
-			set {_loc} to location at 0.5, {SB::config::height}, 0.5 in "%{SB::config::world}%" parsed as world
-			set {SB::searchprocess} to true
-			set {_search} to true
-			set {_s} to 1
-			set {_l} to 1
-			set {_option3} to {SB::config::distance} parsed as number
-			while {_search} is true:
-				loop {_l} times:
-					if {_s} is 1 or 5:
-						add ({SB::config::distance}*2) to Z-coord of {_loc}
-					if {_s} is 2:
-						add  ({SB::config::distance}*2) to X-coord of {_loc}
-					if {_s} is 3:
-						subtract  ({SB::config::distance}*2) from Z-coord of {_loc}
-					if {_s} is 4:
-						subtract  ({SB::config::distance}*2) from X-coord of {_loc}
-					if block at {_loc} is not bedrock:
-						message "%{_prefix}% %{SB::lang::foundis::%{SK::lang::%uuid of player%}%}%"
-						delete {SB::searchis::%player%}
-						add 1 to y-coord of {_loc}
-						set {_schematic} to arg-2
-						set {_backloc} to player's location
-						subtract 1 from y-coord of {_loc}
-						set block at {_loc} to barrier
-						add 1 to y-coord of {_loc}
-						teleport player to {_loc}
-						wait 5 ticks
-						set {_loccx} to "%x-coord of {_loc}%"
-						set {_loccy} to "%y-coord of {_loc}%"
-						set {_loccz} to "%z-coord of {_loc}%"
-						replace all ".5" with "" in {_loccx}
-						set {_loccx} to {_loccx} parsed as integer
-						replace all ".5" with "" in {_loccy}
-						set {_loccy} to {_loccy} parsed as integer
-						replace all ".5" with "" in {_loccz}
-						set {_loccz} to {_loccz} parsed as integer
-						if {_loccx} < 0:
-							set {_loccx} to {_loccx}-1
-						if {_loccz} < 0:
-							set {_loccz} to {_loccz}-1
-						set {_chestloc} to {_loc}
-						set {_homeloc} to {_loc}
-						if {SB::config::isstorage} is "Structure":
-							execute console command "/setblock %{_loccx}% %{_loccy}% %{_loccz}% minecraft:structure_block[mode=load]{name:""%{_schematic}%"",posX:-16,posY:-1,posZ:-16,rotation:""NONE"",mirror:""NONE"",mode:""LOAD""} destroy"
-							wait 5 ticks
-							subtract 1 from y-coord of {_loc}
-							execute console command "/setblock %{_loccx}% %{_loccy}-1% %{_loccz}% minecraft:redstone_block"
-							wait 5 ticks
-						else if {SB::config::isstorage} is "Schematic":
-							#todo add functions for worldedit.
-							broadcast "Schematic is not working right now"
-							stop
-						#HOME start
-						set {_temphomeloc::*} to {SB::schematics::loc::%{_schematic}%::home} split at ","
-						loop {_temphomeloc::*}:
-							set {_temphomeloc::%loop-index%} to {_temphomeloc::%loop-index%} parsed as integer
-						set x-coordinate of {_homeloc} to x-coordinate of {_homeloc} + {_temphomeloc::1}
-						set y-coordinate of {_homeloc} to y-coordinate of {_homeloc} + {_temphomeloc::2}
-						set z-coordinate of {_homeloc} to z-coordinate of {_homeloc} + {_temphomeloc::3}
-						#HOME end
-						#CHEST start
-						#Gets the configurated schematic chest location and places a chest there:
-						set {_tc::*} to {SB::schematics::loc::%{_schematic}%::chest} split at ","
-						loop {_tc::*}:
-							set {_tc::%loop-index%} to {_tc::%loop-index%} parsed as integer
-						set x-coordinate of {_chestloc} to x-coordinate of {_chestloc} + {_tc::1}
-						set y-coordinate of {_chestloc} to y-coordinate of {_chestloc} + {_tc::2}
-						set z-coordinate of {_chestloc} to z-coordinate of {_chestloc} + {_tc::3}
-						set block at {_chestloc} to chest
-						set {_newchest} to block at {_chestloc}
-						loop {SB::schematics::chest::%{_schematic}%::*}:
-							set {_data::*} to loop-value-2 split at ","
-							set {_titem} to "%{_data::2}%" parsed as item
-							set {_tamount} to {_data::1} parsed as integer
-							add {_tamount} of {_titem} to {_newchest}'s inventory
-						#CHEST end
-						set {SB::searchprocess} to false
-						#If something went wrong, teleport player back to backloc variable
-						if block at {_loc} is not bedrock:
-							teleport player to {_backloc}
-							send "&c&o/is create"
-							stop
-						set {_b} to block at {_loc}
-						set {_pis} to {_loc}
-						add 1 to y-coord of {_pis}
-						delete {_search}
-						actionload(player,{SB::lang::foundis::%{SK::lang::%uuid of player%}%})
-						teleport player to {_homeloc}
-						remove blindness from player
-						remove slowness from player
-						set {_l::1} to {_loc}
-						set {_l::2} to {_loc}
-						add ({SB::config::distance} - {SB::config::protect}) to x-coord of {_l::1}
-						add ({SB::config::distance} - {SB::config::protect}) to z-coord of {_l::1}
-						subtract ({SB::config::distance} - {SB::config::protect}) from x-coord of {_l::2}
-						subtract ({SB::config::distance} - {SB::config::protect}) from z-coord of {_l::2}
-						set y-coord of {_l::1} to 256
-						set y-coord of {_l::2} to 0
-						set {_x} to x-coord of {_loc}
-						set {_y} to y-coord of {_loc}
-						set {_z} to z-coord of {_loc}
-						set {SB::island::%{_x}%_%{_y}%_%{_z}%::leader} to uuid of player
-						set {SB::island::%{_x}%_%{_y}%_%{_z}%::level} to 1
-						set {SB::island::%{_x}%_%{_y}%_%{_z}%::exp} to 0
-						set {SB::island::%{_x}%_%{_y}%_%{_z}%::created} to now
-						set {SB::player::%uuid of player%::island::bedrock} to location at {_x}, {_y}, {_z} in "%{SB::config::world}%" parsed as world
-						set {SB::islvl::%{_x}%_%{_y}%_%{_z}%} to 0
-						
-						add 1 to y-coord of {_loc}
-						set {_y} to y-coord of {_loc}						
-						set {SB::island::%{_x}%_%{_y}%_%{_z}%::home::home} to {_homeloc}
-						stop loop
-					wait a ticks
-				if {_s} is 6:
-					set {_s} to 2
-				else:
-					add 1 to {_s}
-				if {_s} is 3 or 5:
-					add 1 to {_l}
-		#
-		# > Argument "flag" ("flags")
-		# > Actions:
-		# > Opens the flag menu using the openflagmenu function.
-		else if arg-1 is "flag" or "flags":
-			openflagmenu(player,"")
-		#
-		# > Argument: "home"
-		# > Actions:
-		# > If the player wants to set, delete or teleport to a home, the homehandler is called here.
-		# > Example command /island home [<player>] [<name>]
-		# > Example command /island sethome [<name>]
-		# > Example command /island delhome [<name>]
-		else if arg-1 is "home" or "sethome" or "delhome":
-			#
-			# > If the player has set a third argument, try to teleport to the home of
-			# > the specified player.
-			if arg-1 is "home":
-				if arg-3 is set:
-					set {_p} to arg-2 parsed as offline player
-					homehandler({_p},arg-1,arg-3,player)
-					stop
-			#
-			# > If the player has not set a third argument, just try to teleport.
-			homehandler(player,arg-1,arg-2,player)
+  aliases: /is, /sb, /skyblock
+  trigger:
+    set {_prefix} to {SB::lang::prefix::%{SK::lang::%uuid of player%}%}
+    if arg-1 is not set:
+      skyblockgui(player)
+    if arg-1 is "reload":
+      if player has permission "%{SB::config::buildpermission}%":
+        make player execute "/sk reload SkyBlock/"
+    if arg-1 is "create":
+      if {SB::player::%uuid of player%::island::bedrock} is set:
+        message "%{_prefix}% %{SB::lang::alreadyis::%{SK::lang::%uuid of player%}%}%"
+        stop
+      #
+      # > If we're already searching for an island for the player, print information and stop.
+      if {SB::searchis::%player%} is set:
+        message "%{_prefix}% %{SB::lang::waitis::%{SK::lang::%uuid of player%}%}%"
+        stop
+      if player is online:
+        if arg-2 is "1":
+          opengui(player,9,"%{SB::lang::islands::%{SK::lang::%uuid of player%}%}%")
+          set {_s} to 0
+          # 
+          # > Go trough all available schematics or structures, which where set in the config.sk and display it in the islands gui.
+          loop {SB::schematics::schematic::*}:
+            set {_item} to grass named "%{SB::schematics::name::%{SK::lang::%uuid of player%}%::%loop-index%}%"
+            setguiitem(player,{_s},"grass",1,"%{SB::schematics::name::%{SK::lang::%uuid of player%}%::%loop-index%}%","","make ""%player%"" parsed as player execute ""/is create %loop-value%""",false)
+            add 1 to {_s}
+          delete {_s}
+          delete {_Bla::*}
+          stop
+        else:
+          #check, if defined schematic exists:
+          if {SB::config::isstorage} is "Schematic":
+            if file "plugins/WorldEdit/schematics/%arg-2%" exists:
+              #security check, is this schematic within the config:
+              set {_ok} to false
+              loop {SB::schematics::schematic::*}:
+                if loop-value is arg-2:
+                  set {_ok} to true
+              #not found, print error and stop:
+              if {_ok} is "false":
+                send "&c&lError"
+                stop
+            #file doesnt exist, print error and stop:
+            else:
+              send "&c&lError"
+              stop
+          #if there is no schematic, don't do anything for now
+          else:
+            set {_ok} to true
+      actionload(player,"start")
+      while {SB::searchprocess} is true:
+        wait 10 ticks
+      if {SB::searchis::%player%} is set:
+        message "%{_prefix}% %{SB::lang::waitis::%{SK::lang::%uuid of player%}%}%"
+        stop
+      else:
+        set {SB::searchis::%player%} to true
+      set {_loc} to location at 0.5, {SB::config::height}, 0.5 in "%{SB::config::world}%" parsed as world
+      set {SB::searchprocess} to true
+      set {_search} to true
+      set {_s} to 1
+      set {_l} to 1
+      set {_option3} to {SB::config::distance} parsed as number
+      while {_search} is true:
+        loop {_l} times:
+          if {_s} is 1 or 5:
+            add ({SB::config::distance}*2) to Z-coord of {_loc}
+          if {_s} is 2:
+            add  ({SB::config::distance}*2) to X-coord of {_loc}
+          if {_s} is 3:
+            subtract  ({SB::config::distance}*2) from Z-coord of {_loc}
+          if {_s} is 4:
+            subtract  ({SB::config::distance}*2) from X-coord of {_loc}
+          if block at {_loc} is not bedrock:
+            message "%{_prefix}% %{SB::lang::foundis::%{SK::lang::%uuid of player%}%}%"
+            delete {SB::searchis::%player%}
+            add 1 to y-coord of {_loc}
+            set {_schematic} to arg-2
+            set {_backloc} to player's location
+            subtract 1 from y-coord of {_loc}
+            set block at {_loc} to barrier
+            add 1 to y-coord of {_loc}
+            teleport player to {_loc}
+            wait 5 ticks
+            set {_loccx} to "%x-coord of {_loc}%"
+            set {_loccy} to "%y-coord of {_loc}%"
+            set {_loccz} to "%z-coord of {_loc}%"
+            replace all ".5" with "" in {_loccx}
+            set {_loccx} to {_loccx} parsed as integer
+            replace all ".5" with "" in {_loccy}
+            set {_loccy} to {_loccy} parsed as integer
+            replace all ".5" with "" in {_loccz}
+            set {_loccz} to {_loccz} parsed as integer
+            if {_loccx} < 0:
+              set {_loccx} to {_loccx}-1
+            if {_loccz} < 0:
+              set {_loccz} to {_loccz}-1
+            set {_chestloc} to {_loc}
+            set {_homeloc} to {_loc}
+            if {SB::config::isstorage} is "Structure":
+              execute console command "/setblock %{_loccx}% %{_loccy}% %{_loccz}% minecraft:structure_block[mode=load]{name:""%{_schematic}%"",posX:-16,posY:-1,posZ:-16,rotation:""NONE"",mirror:""NONE"",mode:""LOAD""} destroy"
+              wait 5 ticks
+              subtract 1 from y-coord of {_loc}
+              execute console command "/setblock %{_loccx}% %{_loccy}-1% %{_loccz}% minecraft:redstone_block"
+              wait 5 ticks
+            else if {SB::config::isstorage} is "Schematic":
+              #todo add functions for worldedit.
+              broadcast "Schematic is not working right now"
+              stop
+            #HOME start
+            set {_temphomeloc::*} to {SB::schematics::loc::%{_schematic}%::home} split at ","
+            loop {_temphomeloc::*}:
+              set {_temphomeloc::%loop-index%} to {_temphomeloc::%loop-index%} parsed as integer
+            set x-coordinate of {_homeloc} to x-coordinate of {_homeloc} + {_temphomeloc::1}
+            set y-coordinate of {_homeloc} to y-coordinate of {_homeloc} + {_temphomeloc::2}
+            set z-coordinate of {_homeloc} to z-coordinate of {_homeloc} + {_temphomeloc::3}
+            #HOME end
+            #CHEST start
+            #Gets the configurated schematic chest location and places a chest there:
+            set {_tc::*} to {SB::schematics::loc::%{_schematic}%::chest} split at ","
+            loop {_tc::*}:
+              set {_tc::%loop-index%} to {_tc::%loop-index%} parsed as integer
+            set x-coordinate of {_chestloc} to x-coordinate of {_chestloc} + {_tc::1}
+            set y-coordinate of {_chestloc} to y-coordinate of {_chestloc} + {_tc::2}
+            set z-coordinate of {_chestloc} to z-coordinate of {_chestloc} + {_tc::3}
+            set block at {_chestloc} to chest
+            set {_newchest} to block at {_chestloc}
+            loop {SB::schematics::chest::%{_schematic}%::*}:
+              set {_data::*} to loop-value-2 split at ","
+              set {_titem} to "%{_data::2}%" parsed as item
+              set {_tamount} to {_data::1} parsed as integer
+              add {_tamount} of {_titem} to {_newchest}'s inventory
+            #CHEST end
+            set {SB::searchprocess} to false
+            #If something went wrong, teleport player back to backloc variable
+            if block at {_loc} is not bedrock:
+              teleport player to {_backloc}
+              send "&c&o/is create"
+              stop
+            set {_b} to block at {_loc}
+            set {_pis} to {_loc}
+            add 1 to y-coord of {_pis}
+            delete {_search}
+            actionload(player,{SB::lang::foundis::%{SK::lang::%uuid of player%}%})
+            teleport player to {_homeloc}
+            remove blindness from player
+            remove slowness from player
+            set {_l::1} to {_loc}
+            set {_l::2} to {_loc}
+            add ({SB::config::distance} - {SB::config::protect}) to x-coord of {_l::1}
+            add ({SB::config::distance} - {SB::config::protect}) to z-coord of {_l::1}
+            subtract ({SB::config::distance} - {SB::config::protect}) from x-coord of {_l::2}
+            subtract ({SB::config::distance} - {SB::config::protect}) from z-coord of {_l::2}
+            set y-coord of {_l::1} to 256
+            set y-coord of {_l::2} to 0
+            set {_x} to x-coord of {_loc}
+            set {_y} to y-coord of {_loc}
+            set {_z} to z-coord of {_loc}
+            set {SB::island::%{_x}%_%{_y}%_%{_z}%::leader} to uuid of player
+            set {SB::island::%{_x}%_%{_y}%_%{_z}%::level} to 1
+            set {SB::island::%{_x}%_%{_y}%_%{_z}%::exp} to 0
+            set {SB::island::%{_x}%_%{_y}%_%{_z}%::created} to now
+            set {SB::player::%uuid of player%::island::bedrock} to location at {_x}, {_y}, {_z} in "%{SB::config::world}%" parsed as world
+            set {SB::islvl::%{_x}%_%{_y}%_%{_z}%} to 0
+            
+            add 1 to y-coord of {_loc}
+            set {_y} to y-coord of {_loc}            
+            set {SB::island::%{_x}%_%{_y}%_%{_z}%::home::home} to {_homeloc}
+            stop loop
+          wait a ticks
+        if {_s} is 6:
+          set {_s} to 2
+        else:
+          add 1 to {_s}
+        if {_s} is 3 or 5:
+          add 1 to {_l}
+    #
+    # > Argument "flag" ("flags")
+    # > Actions:
+    # > Opens the flag menu using the openflagmenu function.
+    else if arg-1 is "flag" or "flags":
+      openflagmenu(player,"")
+    #
+    # > Argument: "home"
+    # > Actions:
+    # > If the player wants to set, delete or teleport to a home, the homehandler is called here.
+    # > Example command /island home [<player>] [<name>]
+    # > Example command /island sethome [<name>]
+    # > Example command /island delhome [<name>]
+    else if arg-1 is "home" or "sethome" or "delhome":
+      #
+      # > If the player has set a third argument, try to teleport to the home of
+      # > the specified player.
+      if arg-1 is "home":
+        if arg-3 is set:
+          set {_p} to arg-2 parsed as offline player
+          homehandler({_p},arg-1,arg-3,player)
+          stop
+      #
+      # > If the player has not set a third argument, just try to teleport.
+      homehandler(player,arg-1,arg-2,player)
 
-		else if arg-1 is "go":
-			if {SB::player::%uuid of player%::island::bedrock} is not set:
-				message "%{_prefix}% %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
-			else:
-				set {_loc} to {SB::player::%uuid of player%::island::bedrock}
-				add 1 to y-coordinate of {_loc}
-				teleport player to {_loc}
-				message "%{_prefix}% %{SB::lang::tpis::%{SK::lang::%uuid of player%}%}%"
+    else if arg-1 is "go":
+      if {SB::player::%uuid of player%::island::bedrock} is not set:
+        message "%{_prefix}% %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
+      else:
+        set {_loc} to {SB::player::%uuid of player%::island::bedrock}
+        add 1 to y-coordinate of {_loc}
+        teleport player to {_loc}
+        message "%{_prefix}% %{SB::lang::tpis::%{SK::lang::%uuid of player%}%}%"
 
-		else if arg-1 are "delete" or "remove":
-			if {SB::player::%uuid of player%::island::bedrock} is not set:
-				message "%{_prefix}% %{SB::lang::cantleave::%{SK::lang::%uuid of player%}%}%"
-			else:
-				#If the 2. argument is 2, then delete, else, create a tellraw which executes this command with the 2. argument.
-				if arg-2 is "2":
-					#todo - ask, if the player really want to delete the island
-					set {_uuid} to uuid of player
-					set {_bedrockloc} to {SB::player::%{_uuid}%::island::bedrock}
-					set {_x} to x-coordinate of {_bedrockloc}
-					set {_y} to y-coordinate of {_bedrockloc}
-					set {_z} to z-coordinate of {_bedrockloc}
-					if difference between {SB::island::%{_x}%_%{_y}%_%{_z}%::created} and now < {SB::config::deletecooldown}:
-						message "%{_prefix}% %{SB::lang::cooldown::%{SK::lang::%uuid of player%}%}%"
-					else:
-						deleteisland(player)
-				else:
-					tellrawmsg1(player,{_prefix},{SB::lang::isdeleteqestion::%{SK::lang::%uuid of player%}%},"/is delete 2")
+    else if arg-1 are "delete" or "remove":
+      if {SB::player::%uuid of player%::island::bedrock} is not set:
+        message "%{_prefix}% %{SB::lang::cantleave::%{SK::lang::%uuid of player%}%}%"
+      else:
+        #If the 2. argument is 2, then delete, else, create a tellraw which executes this command with the 2. argument.
+        if arg-2 is "2":
+          #todo - ask, if the player really want to delete the island
+          set {_uuid} to uuid of player
+          set {_bedrockloc} to {SB::player::%{_uuid}%::island::bedrock}
+          set {_x} to x-coordinate of {_bedrockloc}
+          set {_y} to y-coordinate of {_bedrockloc}
+          set {_z} to z-coordinate of {_bedrockloc}
+          if difference between {SB::island::%{_x}%_%{_y}%_%{_z}%::created} and now < {SB::config::deletecooldown}:
+            message "%{_prefix}% %{SB::lang::cooldown::%{SK::lang::%uuid of player%}%}%"
+          else:
+            deleteisland(player)
+        else:
+          tellrawmsg1(player,{_prefix},{SB::lang::isdeleteqestion::%{SK::lang::%uuid of player%}%},"/is delete 2")
 
-		else if arg-1 is "calc":
-			#If there is more time between the las calculation and now than the set cooldown time in config.sk:
-			if difference between {SB::calcdown::%uuid of player%} and now < {SB::config::calccooldown}:
-				message "%{_prefix}% %{SB::lang::cooldown::%{SK::lang::%uuid of player%}%}%"
-			else:
-				set {SB::calcdown::%uuid of player%} to now
-				set {SB::calcstatus::%player%} to 1
-				$ thread
-				calcisland(player)
-		else if arg-1 is "calcwait":
-			if {SB::calcstatus::%player%} is set:
-				actionload(player,"start")
-				while {SB::calcstatus::%player%} is set:
-					wait 10 ticks
-				set {_uuid} to uuid of player
-				set {_bedrockloc} to {SB::player::%{_uuid}%::island::bedrock}
-				set {_x} to x-coordinate of {_bedrockloc}
-				set {_y} to y-coordinate of {_bedrockloc}
-				set {_z} to z-coordinate of {_bedrockloc}
-				set {_level} to {SB::island::%{_x}%_%{_y}%_%{_z}%::level}
-				actionload(player,"&rLevel: &6&l%{_level}%")
+    else if arg-1 is "calc":
+      #If there is more time between the las calculation and now than the set cooldown time in config.sk:
+      if difference between {SB::calcdown::%uuid of player%} and now < {SB::config::calccooldown}:
+        message "%{_prefix}% %{SB::lang::cooldown::%{SK::lang::%uuid of player%}%}%"
+      else:
+        set {SB::calcdown::%uuid of player%} to now
+        set {SB::calcstatus::%player%} to 1
+        $ thread
+        calcisland(player)
+    else if arg-1 is "calcwait":
+      if {SB::calcstatus::%player%} is set:
+        actionload(player,"start")
+        while {SB::calcstatus::%player%} is set:
+          wait 10 ticks
+        set {_uuid} to uuid of player
+        set {_bedrockloc} to {SB::player::%{_uuid}%::island::bedrock}
+        set {_x} to x-coordinate of {_bedrockloc}
+        set {_y} to y-coordinate of {_bedrockloc}
+        set {_z} to z-coordinate of {_bedrockloc}
+        set {_level} to {SB::island::%{_x}%_%{_y}%_%{_z}%::level}
+        actionload(player,"&rLevel: &6&l%{_level}%")
 
-		else if arg-1 is "top":
-			if {SB::islvl::*} is set:
-				loop {SB::islvl::*}:
-					set {_loc::*} to loop-index split at "_"
-					set {_loc::1} to {_loc::1} parsed as number
-					set {_loc::2} to {_loc::2} parsed as number
-					set {_loc::3} to {_loc::3} parsed as number
-					set {_uuid} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::leader}
-					set {_level} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::level}
-					set {_exp} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::exp}
-					set {_Level::%{_uuid}%} to {_level}
-				loop {_Level::*}:
-					add 1 to {_size}
-					if {_low.to.high.list::%loop-value%} is not set:
-						set {_low.to.high.list::%loop-value%} to loop-index
-					else:
-						set {_n} to 0
-						loop {_size} times:
-							set {_n} to {_n}+1
-							{_low.to.high.list::%loop-value-1%.%{_n}%} is not set
-							set {_low.to.high.list::%loop-value-1%.%{_n}%} to loop-index
-							stop loop
-				wait 1 tick
-				set {_n} to size of {_low.to.high.list::*}
-				loop {_low.to.high.list::*}:
-					set {_high.to.low.list::%{_n}%} to loop-value
-					set {_n} to {_n}-1
-				wait 1 tick
-				set {_page} to 1
-				loop {_high.to.low.list::*}:
-					add 1 to {_result}
-					add 1 to {_r}
-					set {_Top::%{_page}%::%{_r}%} to loop-value
-					if loop-value is player:
-						set {_rank} to {_r}
-					else:
-						loop {_Member::%loop-value%::*}:
-							if loop-value-2 is player:
-								set {_rank} to {_r}
-					if {_result} is 10:
-						set {_result} to 0
-						add 1 to {_page}
-				set {_arg1} to arg-2 parsed as number
-				if {_arg1} is not set:
-					message "%{_prefix}% %{SB::lang::notanumber::%{SK::lang::%uuid of player%}%}%"
-					stop
-				else:
-					if {_top::%{_arg1}%::*} is not set:
-						message "%{_prefix}% %{SB::lang::pagenotfound::%{SK::lang::%uuid of player%}%}%"
-						stop
-				if {_Rank} is not set:
-					set {_rank} to "-/-"
-				message "%{SB::config::spacer}%"
-				send "%{SB::lang::prefix::%{SK::lang::%uuid of player%}%}%&6&l &eTop 10 &6&l(%arg-2%/%{_page}%)"
-				loop {_Top::%arg-2%::*}:
-					set {_member} to ""
-					set {_loc} to {SB::player::%loop-value%::island::bedrock}
-					set {_locx} to x-coord of {_loc}
-					set {_locy} to y-coord of {_loc}
-					set {_locz} to z-coord of {_loc}
-					loop {SB::island::%{_locx}%_%{_locy}%_%{_locz}%::member::*}:
-						set {_tp} to "%loop-value-2%" parsed as offline player
-						if {_member} is "":
-							set {_member} to "%{_tp}%"
-						else:
-							set {_member} to "%{_member}%, %{_tp}%"
-					set {_p} to "%loop-value%" parsed as offline player
-					if player is {_p}:
-						set {_rank} to loop-index
-					send  "&e&l%loop-index%&8 - &6%{_p}%&7&l: &e%{_Level::%loop-value%}% &7||&8 %{_Member}%"
-				set {_size} to size of {SB::islvl::*}
-				send "%{SB::lang::prefix::%{SK::lang::%uuid of player%}%}% &eDu bist auf Platz %{_rank}% von %{_size}% Inseln. todo: translate"
-				message "%{SB::config::spacer}%"
-			else:
-				message "%{_prefix}% %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
-		else if arg-1 is "level" or "lvl":
-			if {SB::player::%uuid of player%::island::bedrock} is not set:
-				message "%{_prefix}%  %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
-			else:
-				set {_loc} to {SB::player::%uuid of player%::island::bedrock}
-				set {_locx} to x-coord of {_loc}
-				set {_locy} to y-coord of {_loc}
-				set {_locz} to z-coord of {_loc}
-				set {_level} to {SB::island::%{_locx}%_%{_locy}%_%{_locz}%::level}
-				set {_p} to {SB::lang::prefix::%{SK::lang::%uuid of player%}%}
-				message "%{SB::config::spacer}%"
-				message "%{_p}%%{SB::lang::levelheader::%{SK::lang::%uuid of player%}%}%%{_level}%" to player
-				message "%{_p}% Calculate your level with /is calc -todo: translation" to player
-				message "%{SB::config::spacer}%"
-		else if arg-1 is "spawn" or "lobby":
-			teleport player to {SB::config::spawn}
-		else if arg-1 is "invite":
-			if {SB::player::%uuid of player%::island::bedrock} is set:
-				set {_leader} to getleader(player)
-				if {_leader} is uuid of player:
-					set {_arg2} to arg-2 parsed as offline player
-					if {_arg2} is online:
-						if {_arg2} is not player:
-							set {_p2} to {_arg2}
-							set {_tuuid} to uuid of {_p2}
-							if {SB::player::%{_tuuid}%::island::bedrock} is set:
-								set {_msg} to {SB::lang::alreadyotheris::%{SK::lang::%uuid of player%}%}
-								replace all "<player>" with "%{_p2}%" in {_msg}
-								message "%{_prefix}% %{_msg}%"
-								stop
-							set {_uuid2} to uuid of {_arg2}
-							set {_b} to {SB::lang::gotrequest::%{SK::lang::%{_uuid2}%}%}
-							message "%{_prefix}% %{SB::lang::sentrequest::%{SK::lang::%uuid of player%}%}%"
-							replace all "<player>" in {_b} with "%player%"
-							message "%{_prefix}% %{_b}%" to {_p2}
-							set {_uuidp2} to uuid of {_p2}
-							set {_msg} to {SB::lang::clicktojoin::%{SK::lang::%{_uuidp2}%}%}
-							replace all "<player>" with "%player%" in {_msg}
-							#todo  the function could execute the console command by itself, there is no need to do it this way
-							tellrawmsg1({_p2},{_prefix},{_msg},"/is join %player%")
-							set {_cooldown} to {SB::config::invitecooldown}
-							set {_cooldown} to {_cooldown} parsed as number
-							set {Request::%{_arg2}%::%player%} to {_cooldown}
-							while {Request::%{_arg2}%::%player%} > 0:
-								subtract 1 from {Request::%{_arg2}%::%player%}
-								wait a second
-							if {Request::%{_arg2}%::%player%} is 0:
-								delete {Request::%{_arg2}%::%player%}
-								set {_a} to {SB::lang::reqtoleader::%{SK::lang::%uuid of player%}%}
-								set {_uuid2} to uuid of {_arg2}
-								set {_b} to {SB::lang::reqtomember::%{SK::lang::%{_uuid2}%}%}
-								message "%{_prefix}% %{_a}%"
-								message "%{_prefix}% %{_b}%" to {_p2}
-						else:
-							set {_a} to {SB::lang::cantinviteself::%{SK::lang::%uuid of player%}%}
-							message "%{_prefix}% %{_a}%"
-					else:
-						set {_a} to {SB::lang::playeroff::%{SK::lang::%uuid of player%}%}
-						message "%{_prefix}% %{_a}%"
-				else:
-					set {_a} to {SB::lang::notleader::%{SK::lang::%uuid of player%}%}
-					message "%{_prefix}% %{_a}%"
-			else:
-				message "%{_prefix}% %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
-		else if arg-1 is "join":
-			set {_arg2} to arg-2 parsed as offline player
-			if {_arg2} is "1":
-				loop {Request::%player%::*}:
-					set {_tplayer} to loop-index parsed as offline player
-					set {_msg} to {SB::lang::clicktojoin::%{SK::lang::%uuid of player%}%}
-					replace all "<player>" with "%{_tplayer}%" in {_msg}
-					tellrawmsg1(player,{_prefix},{_msg},"/is join %{_tplayer}%")
-				if size of {Request::%player%::*} is 0:
-					message "%{_prefix}% %{SB::lang::norequest::%{SK::lang::%uuid of player%}%}%" to player
-				stop
-			else if {_arg2} is set:
-				if {Request::%player%::%{_arg2}%} is set:
-					if {SB::player::%uuid of player%::island::bedrock} is set:
-						message "%{_prefix}% %{SB::lang::alreadyis::%{SK::lang::%uuid of player%}%}%"
-						set {_check} to getleader(player)
-						if {_check} is uuid of player:
-							message "%{_prefix}% %{SB::lang::havetodelete::%{SK::lang::%uuid of player%}%}%"
-						else:
-							message "%{_prefix}% %{SB::lang::havetoleave::%{SK::lang::%uuid of player%}%}%"
-					else:
-						#todo - add a function which adds a member to the island with 2 agruments?
-						set {_uuid} to uuid of {_arg2}
-						set {_loc} to {SB::player::%{_uuid}%::island::bedrock}
-						set {_locx} to x-coord of {_loc}
-						set {_locy} to y-coord of {_loc}
-						set {_locz} to z-coord of {_loc}
-						add uuid of player to {SB::island::%{_locx}%_%{_locy}%_%{_locz}%::member::*}
-						set {_pluuid} to uuid of {_arg2}
-						set {_joinuuid} to uuid of player
-						set {SB::player::%{_joinuuid}%::island::bedrock} to {SB::player::%{_pluuid}%::island::bedrock}
-						delete {Request::%player%::%{_arg2}%}
-						make player execute command "/is home"
-						set {_a} to {SB::lang::joinedismember::%{SK::lang::%uuid of player%}%}
-						set {_uuid2} to uuid of {_arg2}
-						set {_b} to {SB::lang::joinedisleader::%{SK::lang::%{_uuid2}%}%}
-						replace all "<arg-2>" in {_a} with "%{_arg2}%"
-						replace all "<player>" in {_b} with "%player%"
-						message "%{_prefix}% %{_a}%"
-						set {_p2} to {_arg2}
-						message "%{_prefix}% %{_b}%" to {_p2}
-				else:
-					set {_a} to {SB::lang::norequest::%{SK::lang::%uuid of player%}%}
-					message "%{_prefix}% %{_a}%"
-			else:
-				set {_a} to {SB::lang::invitetargeterror::%{SK::lang::%uuid of player%}%}
-				message "%{_prefix}% %{_a}%"
-		else if arg-1 is "leave":
-			if {SB::player::%uuid of player%::island::bedrock} is not set:
-				message "%{_prefix}% %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
-			else:
-				#
-				# > Doesn't allow the leader to leave the island.
-				set {_leader} to getleader(player)
-				if {_leader} is uuid of player:
-					message "%{_prefix}% %{SB::lang::leaderleaveinfo::%{SK::lang::%uuid of player%}%}%"
-				#
-				# > If the player is not a leader, the player can leave.
-				else:
-					if arg-2 is player:
-						message "%{_prefix}% %{SB::lang::deletekickmember::%{SK::lang::%uuid of player%}%}%"
-						leaveisland(player, "member")
-					else:
-						message "%{_prefix}% %{SB::lang::leftis::%{SK::lang::%uuid of player%}%}%"
-						leaveisland(player, "owner")
+    else if arg-1 is "top":
+      if {SB::islvl::*} is set:
+        loop {SB::islvl::*}:
+          set {_loc::*} to loop-index split at "_"
+          set {_loc::1} to {_loc::1} parsed as number
+          set {_loc::2} to {_loc::2} parsed as number
+          set {_loc::3} to {_loc::3} parsed as number
+          set {_uuid} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::leader}
+          set {_level} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::level}
+          set {_exp} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::exp}
+		  #
+		  # > If there is already a level set for this player, delete the list entry.
+          if {_Level::%{_uuid}%} is set:
+            delete {SB::islvl::%loop-index%}
+          set {_Level::%{_uuid}%} to {_level}
+        loop {_Level::*}:
+          add 1 to {_size}
+          if {_low.to.high.list::%loop-value%} is not set:
+            set {_low.to.high.list::%loop-value%} to loop-index
+          else:
+            set {_n} to 0
+            loop {_size} times:
+              set {_n} to {_n}+1
+              {_low.to.high.list::%loop-value-1%.%{_n}%} is not set
+              set {_low.to.high.list::%loop-value-1%.%{_n}%} to loop-index
+              stop loop
+        wait 1 tick
+        set {_n} to size of {_low.to.high.list::*}
+        loop {_low.to.high.list::*}:
+          set {_high.to.low.list::%{_n}%} to loop-value
+          set {_n} to {_n}-1
+        wait 1 tick
+        set {_page} to 1
+        loop {_high.to.low.list::*}:
+          add 1 to {_result}
+          add 1 to {_r}
+          set {_Top::%{_page}%::%{_r}%} to loop-value
+          if loop-value is player:
+            set {_rank} to {_r}
+          else:
+            loop {_Member::%loop-value%::*}:
+              if loop-value-2 is player:
+                set {_rank} to {_r}
+          if {_result} is 10:
+            set {_result} to 0
+            add 1 to {_page}
+        set {_arg1} to arg-2 parsed as number
+        if {_arg1} is not set:
+          message "%{_prefix}% %{SB::lang::notanumber::%{SK::lang::%uuid of player%}%}%"
+          stop
+        else:
+          if {_top::%{_arg1}%::*} is not set:
+            message "%{_prefix}% %{SB::lang::pagenotfound::%{SK::lang::%uuid of player%}%}%"
+            stop
+        if {_Rank} is not set:
+          set {_rank} to "-/-"
+        message "%{SB::config::spacer}%"
+        send "%{SB::lang::prefix::%{SK::lang::%uuid of player%}%}%&6&l &eTop 10 &6&l(%arg-2%/%{_page}%)"
+        loop {_Top::%arg-2%::*}:
+          set {_member} to ""
+          set {_loc} to {SB::player::%loop-value%::island::bedrock}
+          set {_locx} to x-coord of {_loc}
+          set {_locy} to y-coord of {_loc}
+          set {_locz} to z-coord of {_loc}
+          loop {SB::island::%{_locx}%_%{_locy}%_%{_locz}%::member::*}:
+            set {_tp} to "%loop-value-2%" parsed as offline player
+            if {_member} is "":
+              set {_member} to "%{_tp}%"
+            else:
+              set {_member} to "%{_member}%, %{_tp}%"
+          set {_p} to "%loop-value%" parsed as offline player
+          if player is {_p}:
+            set {_rank} to loop-index
+          send  "&e&l%loop-index%&8 - &6%{_p}%&7&l: &e%{_Level::%loop-value%}% &7||&8 %{_Member}%"
+        set {_size} to size of {SB::islvl::*}
+        send "%{SB::lang::prefix::%{SK::lang::%uuid of player%}%}% &eDu bist auf Platz %{_rank}% von %{_size}% Inseln. todo: translate"
+        message "%{SB::config::spacer}%"
+      else:
+        message "%{_prefix}% %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
+    else if arg-1 is "level" or "lvl":
+      if {SB::player::%uuid of player%::island::bedrock} is not set:
+        message "%{_prefix}%  %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
+      else:
+        set {_loc} to {SB::player::%uuid of player%::island::bedrock}
+        set {_locx} to x-coord of {_loc}
+        set {_locy} to y-coord of {_loc}
+        set {_locz} to z-coord of {_loc}
+        set {_level} to {SB::island::%{_locx}%_%{_locy}%_%{_locz}%::level}
+        set {_p} to {SB::lang::prefix::%{SK::lang::%uuid of player%}%}
+        message "%{SB::config::spacer}%"
+        message "%{_p}%%{SB::lang::levelheader::%{SK::lang::%uuid of player%}%}%%{_level}%" to player
+        message "%{_p}% Calculate your level with /is calc -todo: translation" to player
+        message "%{SB::config::spacer}%"
+    else if arg-1 is "spawn" or "lobby":
+      teleport player to {SB::config::spawn}
+    else if arg-1 is "invite":
+      if {SB::player::%uuid of player%::island::bedrock} is set:
+        set {_leader} to getleader(player)
+        if {_leader} is uuid of player:
+          set {_arg2} to arg-2 parsed as offline player
+          if {_arg2} is online:
+            if {_arg2} is not player:
+              set {_p2} to {_arg2}
+              set {_tuuid} to uuid of {_p2}
+              if {SB::player::%{_tuuid}%::island::bedrock} is set:
+                set {_msg} to {SB::lang::alreadyotheris::%{SK::lang::%uuid of player%}%}
+                replace all "<player>" with "%{_p2}%" in {_msg}
+                message "%{_prefix}% %{_msg}%"
+                stop
+              set {_uuid2} to uuid of {_arg2}
+              set {_b} to {SB::lang::gotrequest::%{SK::lang::%{_uuid2}%}%}
+              message "%{_prefix}% %{SB::lang::sentrequest::%{SK::lang::%uuid of player%}%}%"
+              replace all "<player>" in {_b} with "%player%"
+              message "%{_prefix}% %{_b}%" to {_p2}
+              set {_uuidp2} to uuid of {_p2}
+              set {_msg} to {SB::lang::clicktojoin::%{SK::lang::%{_uuidp2}%}%}
+              replace all "<player>" with "%player%" in {_msg}
+              #todo  the function could execute the console command by itself, there is no need to do it this way
+              tellrawmsg1({_p2},{_prefix},{_msg},"/is join %player%")
+              set {_cooldown} to {SB::config::invitecooldown}
+              set {_cooldown} to {_cooldown} parsed as number
+              set {Request::%{_arg2}%::%player%} to {_cooldown}
+              while {Request::%{_arg2}%::%player%} > 0:
+                subtract 1 from {Request::%{_arg2}%::%player%}
+                wait a second
+              if {Request::%{_arg2}%::%player%} is 0:
+                delete {Request::%{_arg2}%::%player%}
+                set {_a} to {SB::lang::reqtoleader::%{SK::lang::%uuid of player%}%}
+                set {_uuid2} to uuid of {_arg2}
+                set {_b} to {SB::lang::reqtomember::%{SK::lang::%{_uuid2}%}%}
+                message "%{_prefix}% %{_a}%"
+                message "%{_prefix}% %{_b}%" to {_p2}
+            else:
+              set {_a} to {SB::lang::cantinviteself::%{SK::lang::%uuid of player%}%}
+              message "%{_prefix}% %{_a}%"
+          else:
+            set {_a} to {SB::lang::playeroff::%{SK::lang::%uuid of player%}%}
+            message "%{_prefix}% %{_a}%"
+        else:
+          set {_a} to {SB::lang::notleader::%{SK::lang::%uuid of player%}%}
+          message "%{_prefix}% %{_a}%"
+      else:
+        message "%{_prefix}% %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
+    else if arg-1 is "join":
+      set {_arg2} to arg-2 parsed as offline player
+      if {_arg2} is "1":
+        loop {Request::%player%::*}:
+          set {_tplayer} to loop-index parsed as offline player
+          set {_msg} to {SB::lang::clicktojoin::%{SK::lang::%uuid of player%}%}
+          replace all "<player>" with "%{_tplayer}%" in {_msg}
+          tellrawmsg1(player,{_prefix},{_msg},"/is join %{_tplayer}%")
+        if size of {Request::%player%::*} is 0:
+          message "%{_prefix}% %{SB::lang::norequest::%{SK::lang::%uuid of player%}%}%" to player
+        stop
+      else if {_arg2} is set:
+        if {Request::%player%::%{_arg2}%} is set:
+          if {SB::player::%uuid of player%::island::bedrock} is set:
+            message "%{_prefix}% %{SB::lang::alreadyis::%{SK::lang::%uuid of player%}%}%"
+            set {_check} to getleader(player)
+            if {_check} is uuid of player:
+              message "%{_prefix}% %{SB::lang::havetodelete::%{SK::lang::%uuid of player%}%}%"
+            else:
+              message "%{_prefix}% %{SB::lang::havetoleave::%{SK::lang::%uuid of player%}%}%"
+          else:
+            #todo - add a function which adds a member to the island with 2 agruments?
+            set {_uuid} to uuid of {_arg2}
+            set {_loc} to {SB::player::%{_uuid}%::island::bedrock}
+            set {_locx} to x-coord of {_loc}
+            set {_locy} to y-coord of {_loc}
+            set {_locz} to z-coord of {_loc}
+            add uuid of player to {SB::island::%{_locx}%_%{_locy}%_%{_locz}%::member::*}
+            set {_pluuid} to uuid of {_arg2}
+            set {_joinuuid} to uuid of player
+            set {SB::player::%{_joinuuid}%::island::bedrock} to {SB::player::%{_pluuid}%::island::bedrock}
+            delete {Request::%player%::%{_arg2}%}
+            make player execute command "/is home"
+            set {_a} to {SB::lang::joinedismember::%{SK::lang::%uuid of player%}%}
+            set {_uuid2} to uuid of {_arg2}
+            set {_b} to {SB::lang::joinedisleader::%{SK::lang::%{_uuid2}%}%}
+            replace all "<arg-2>" in {_a} with "%{_arg2}%"
+            replace all "<player>" in {_b} with "%player%"
+            message "%{_prefix}% %{_a}%"
+            set {_p2} to {_arg2}
+            message "%{_prefix}% %{_b}%" to {_p2}
+        else:
+          set {_a} to {SB::lang::norequest::%{SK::lang::%uuid of player%}%}
+          message "%{_prefix}% %{_a}%"
+      else:
+        set {_a} to {SB::lang::invitetargeterror::%{SK::lang::%uuid of player%}%}
+        message "%{_prefix}% %{_a}%"
+    else if arg-1 is "leave":
+      if {SB::player::%uuid of player%::island::bedrock} is not set:
+        message "%{_prefix}% %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
+      else:
+        #
+        # > Doesn't allow the leader to leave the island.
+        set {_leader} to getleader(player)
+        if {_leader} is uuid of player:
+          message "%{_prefix}% %{SB::lang::leaderleaveinfo::%{SK::lang::%uuid of player%}%}%"
+        #
+        # > If the player is not a leader, the player can leave.
+        else:
+          if arg-2 is player:
+            message "%{_prefix}% %{SB::lang::deletekickmember::%{SK::lang::%uuid of player%}%}%"
+            leaveisland(player, "member")
+          else:
+            message "%{_prefix}% %{SB::lang::leftis::%{SK::lang::%uuid of player%}%}%"
+            leaveisland(player, "owner")
 
-		# > Argument: "kick"
-		# > If a player types in /island with the first argument "kick" and the second argument with the player name of the
-		# > player who should get kicked, then the following code is investigating if the user has an island, is the owner of his island,
-		# > has a member by that name on his member list and then fire the "leaveisland" function, if the player was found.
-		else if arg-1 is "kick":
-			if {SB::player::%uuid of player%::island::bedrock} is not set:
-				message "%{_prefix}% %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
-			else:
-				#
-				# > Check if the executor is the island leader.
-				set {_leader} to getleader(player)
-				if {_leader} is uuid of player:
-					if arg-2 is set:
-						set {_kickplayer} to arg-2 parsed as offline player
-						set {_uuid} to uuid of {_kickplayer}
-						set {_loc} to {SB::player::%uuid of player%::island::bedrock}
-						set {_locx} to x-coord of {_loc}
-						set {_locy} to y-coord of {_loc}
-						set {_locz} to z-coord of {_loc}
-						loop {SB::island::%{_locx}%_%{_locy}%_%{_locz}%::member::*}:
-							if loop-value is uuid of {_kickplayer}:
-								delete {SB::island::%{_locx}%_%{_locy}%_%{_locz}%::member::%loop-index%}
-								set {_a} to {SB::lang::kickmemberleader::%{SK::lang::%uuid of player%}%}
-								set {_b} to {SB::lang::kickmember::%{SK::lang::%{_uuid}%}%}
-								set {_p2} to arg-2 parsed as offline player
-								replace all "<arg-2>" in {_a} with arg-2
-								replace all "<player>" in {_b} with "%player%"
-								message "%{_prefix}% %{_a}%"
-								leaveisland({_p2}, "member")
-								stop
-						set {_a} to {SB::lang::plnotfound::%{SK::lang::%uuid of player%}%}
-						replace all "<player>" with arg-2 in {_a}
-						message "%{_prefix}% %{_a}%"
-					else:
-						set {_a} to {SB::lang::invitetargeterror::%{SK::lang::%uuid of player%}%}
-						message "%{_prefix}% %{_a}%"
-				else:
-					actionload(player,{SB::lang::noperm::%{SK::lang::%uuid of player%}%})
-		else if arg-1 is "help":
-			set {_site} to arg-2 parsed as integer
-			if {_site} is more than 5:
-				message "%{_prefix}% %{SB::lang::helpsiteerror::%{SK::lang::%uuid of player%}%}%"""
-				stop
-			send "%{SB::config::spacer}%"
-			if arg-2 is "1":
-				message "%{_prefix}% %{SB::lang::iscreate::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::isdelete::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::isteleport::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::issethome::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::isteleportgo::%{SK::lang::%uuid of player%}%}%"
-			else if arg-2 is "2":
-				message "%{_prefix}% %{SB::lang::islevel::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::istop::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::isinvite::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::iskick::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::isjoin::%{SK::lang::%uuid of player%}%}%"
-			else if arg-2 is "3":
-				message "%{_prefix}% %{SB::lang::isleave::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::isgui::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::isspawn::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::isore::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::isgen::%{SK::lang::%uuid of player%}%}%"
-			else if arg-2 is "4":
-				message "%{_prefix}% %{SB::lang::trustadd::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::trustremove::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::trustlist::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::helpwarp::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% %{SB::lang::helpsetwarp::%{SK::lang::%uuid of player%}%}%"
-			else if arg-2 is "5":
-				message "%{_prefix}% %{SB::lang::helpdelwarp::%{SK::lang::%uuid of player%}%}%"
-			send "%{_prefix}% &7%{SB::lang::helps2::%{SK::lang::%uuid of player%}%}%: %{_site}%/5 - %{SB::lang::helpsiteerror::%{SK::lang::%uuid of player%}%}%" to player
-			send "%{SB::config::spacer}%"
+    # > Argument: "kick"
+    # > If a player types in /island with the first argument "kick" and the second argument with the player name of the
+    # > player who should get kicked, then the following code is investigating if the user has an island, is the owner of his island,
+    # > has a member by that name on his member list and then fire the "leaveisland" function, if the player was found.
+    else if arg-1 is "kick":
+      if {SB::player::%uuid of player%::island::bedrock} is not set:
+        message "%{_prefix}% %{SB::lang::nois::%{SK::lang::%uuid of player%}%}%"
+      else:
+        #
+        # > Check if the executor is the island leader.
+        set {_leader} to getleader(player)
+        if {_leader} is uuid of player:
+          if arg-2 is set:
+            set {_kickplayer} to arg-2 parsed as offline player
+            set {_uuid} to uuid of {_kickplayer}
+            set {_loc} to {SB::player::%uuid of player%::island::bedrock}
+            set {_locx} to x-coord of {_loc}
+            set {_locy} to y-coord of {_loc}
+            set {_locz} to z-coord of {_loc}
+            loop {SB::island::%{_locx}%_%{_locy}%_%{_locz}%::member::*}:
+              if loop-value is uuid of {_kickplayer}:
+                delete {SB::island::%{_locx}%_%{_locy}%_%{_locz}%::member::%loop-index%}
+                set {_a} to {SB::lang::kickmemberleader::%{SK::lang::%uuid of player%}%}
+                set {_b} to {SB::lang::kickmember::%{SK::lang::%{_uuid}%}%}
+                set {_p2} to arg-2 parsed as offline player
+                replace all "<arg-2>" in {_a} with arg-2
+                replace all "<player>" in {_b} with "%player%"
+                message "%{_prefix}% %{_a}%"
+                leaveisland({_p2}, "member")
+                stop
+            set {_a} to {SB::lang::plnotfound::%{SK::lang::%uuid of player%}%}
+            replace all "<player>" with arg-2 in {_a}
+            message "%{_prefix}% %{_a}%"
+          else:
+            set {_a} to {SB::lang::invitetargeterror::%{SK::lang::%uuid of player%}%}
+            message "%{_prefix}% %{_a}%"
+        else:
+          actionload(player,{SB::lang::noperm::%{SK::lang::%uuid of player%}%})
+    else if arg-1 is "help":
+      set {_site} to arg-2 parsed as integer
+      if {_site} is more than 5:
+        message "%{_prefix}% %{SB::lang::helpsiteerror::%{SK::lang::%uuid of player%}%}%"""
+        stop
+      send "%{SB::config::spacer}%"
+      if arg-2 is "1":
+        message "%{_prefix}% %{SB::lang::iscreate::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::isdelete::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::isteleport::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::issethome::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::isteleportgo::%{SK::lang::%uuid of player%}%}%"
+      else if arg-2 is "2":
+        message "%{_prefix}% %{SB::lang::islevel::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::istop::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::isinvite::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::iskick::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::isjoin::%{SK::lang::%uuid of player%}%}%"
+      else if arg-2 is "3":
+        message "%{_prefix}% %{SB::lang::isleave::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::isgui::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::isspawn::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::isore::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::isgen::%{SK::lang::%uuid of player%}%}%"
+      else if arg-2 is "4":
+        message "%{_prefix}% %{SB::lang::trustadd::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::trustremove::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::trustlist::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::helpwarp::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% %{SB::lang::helpsetwarp::%{SK::lang::%uuid of player%}%}%"
+      else if arg-2 is "5":
+        message "%{_prefix}% %{SB::lang::helpdelwarp::%{SK::lang::%uuid of player%}%}%"
+      send "%{_prefix}% &7%{SB::lang::helps2::%{SK::lang::%uuid of player%}%}%: %{_site}%/5 - %{SB::lang::helpsiteerror::%{SK::lang::%uuid of player%}%}%" to player
+      send "%{SB::config::spacer}%"
 
-		#
-		# > Argument: "info"
-		# > If a player types in /island info, the the following code is being executed.
-		# > Actions:
-		# > Starts the "searchbedrock" function with the player as argument, if the return location is is not at y-coordinate -5, go forward.
-		# > Then it takes the location apart in x, y, z coordinates and gets all the variables from the main location of the island, where the
-		# > Bedrock is placed at and displays the data.
-		#
-		else if arg-1 is "info":
-			set {_bedrock} to searchbedrock(player)
-			if y-coordinate of {_bedrock} is -5:
-				#
-				# > Prints the defined spacers and a message that the island could not be found:
-				#
-				message "%{SB::config::spacer}%"
-				message "%{_prefix}% %{SB::lang::isinfonotfound::%{SK::lang::%uuid of player%}%}%"
-				message "%{SB::config::spacer}%"
-			else:
-				set {_loc::1} to x-coord of {_bedrock}
-				set {_loc::2} to y-coord of {_bedrock}
-				set {_loc::3} to z-coord of {_bedrock}
-				
-				set {_uuid} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::leader} parsed as offline player
-				set {_realuuid} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::leader}
-				set {_level} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::level}
-				set {_exp} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::exp}
-				set {_created} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::created}
-				set {_lastactive} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::lastactive}
-				set {_hopperlevel} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::hopperupgrade}
-				set {_sizelevel} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::sizeupgrade}
-				set {_homelevel} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::homeupgrade}
-				#
-				# > If the levels aren't set, set them to 0.
-				if {_hopperlevel} is not set:
-					set {_hopperlevel} to 0
-				if {_sizelevel} is not set:
-					set {_sizelevel} to 0
-				if {_homelevel} is not set:
-					set {_homelevel} to 0
-				
-				#
-				# > Go trough all members and add them as a player to a new array.
-				loop {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::member::*}:
-					add "%loop-value%" parsed as offline player to {_member::*} 
-				#
-				# > Go trough all trusted players and add them as a player to a new array.
-				loop {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::trust::*}:
-					add "%loop-value%" parsed as offline player to {_trusted::*} 
+    #
+    # > Argument: "info"
+    # > If a player types in /island info, the the following code is being executed.
+    # > Actions:
+    # > Starts the "checkislandaccess" function with the player and location of player as parameter, if the return location is is not at y-coordinate -5, go forward.
+    # > Then it takes the location apart in x, y, z coordinates and gets all the variables from the main location of the island, where the
+    # > Bedrock is placed at and displays the data.
+    #
+    else if arg-1 is "info":
+      #
+	  # > Update the temporary location of the island bedrock, the player is on.
+      set {_d} to checkislandaccess(player, location of player)
+      #
+      # > Set the {_bedrock} variable to the current temporary location of the bedrock.
+      set {_bedrock} to {SB::TEMPLOC::%player%}
+      if y-coordinate of {_bedrock} is -5:
+        #
+        # > Prints the defined spacers and a message that the island could not be found:
+        #
+        message "%{SB::config::spacer}%"
+        message "%{_prefix}% %{SB::lang::isinfonotfound::%{SK::lang::%uuid of player%}%}%"
+        message "%{SB::config::spacer}%"
+      else:
+        set {_loc::1} to x-coord of {_bedrock}
+        set {_loc::2} to y-coord of {_bedrock}
+        set {_loc::3} to z-coord of {_bedrock}
+        
+        set {_uuid} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::leader} parsed as offline player
+        set {_realuuid} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::leader}
+        set {_level} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::level}
+        set {_exp} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::exp}
+        set {_created} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::created}
+        set {_lastactive} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::lastactive}
+        set {_hopperlevel} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::hopperupgrade}
+        set {_sizelevel} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::sizeupgrade}
+        set {_homelevel} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::homeupgrade}
+        #
+        # > If the levels aren't set, set them to 0.
+        if {_hopperlevel} is not set:
+          set {_hopperlevel} to 0
+        if {_sizelevel} is not set:
+          set {_sizelevel} to 0
+        if {_homelevel} is not set:
+          set {_homelevel} to 0
+        
+        #
+        # > Go trough all members and add them as a player to a new array.
+        loop {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::member::*}:
+          add "%loop-value%" parsed as offline player to {_member::*} 
+        #
+        # > Go trough all trusted players and add them as a player to a new array.
+        loop {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::trust::*}:
+          add "%loop-value%" parsed as offline player to {_trusted::*} 
 
-				#
-				# > Prints the defined spacer:
-				message "%{SB::config::spacer}%"
-				#
-				# > Prints the header:
-				message "%{_prefix}% %{SB::lang::isinfo::%{SK::lang::%uuid of player%}%}%"
-				#
-				# > Prints the leader of the island:
-				message "%{_prefix}% %{SB::lang::isleader::%{SK::lang::%uuid of player%}%}% %{_uuid}%"
-				#
-				# > Prints the members, if there is at least one member:
-				if size of {_member::*} is not 0:
-					message "%{_prefix}% %{SB::lang::ismember::%{SK::lang::%uuid of player%}%}% %{_member::*}%"
-				#
-				# > Prints the trusted player, if there is at least one trusted player:
-				if size of {_trusted::*} is not 0:
-					message "%{_prefix}% %{SB::lang::istrusted::%{SK::lang::%uuid of player%}%}% %{_trusted::*}%"
-				#
-				# > Prints the island info:
-				message "%{_prefix}% %{SB::lang::isinfolevel::%{SK::lang::%uuid of player%}%}% %{_level}%"
-				#
-				# > Prints the creation date of the island:
-				message "%{_prefix}% %{SB::lang::iscreated::%{SK::lang::%uuid of player%}%}% %{_created}%"
-				#
-				# > Prints the last active date of the island:
-				message "%{_prefix}% %{SB::lang::islastactive::%{SK::lang::%uuid of player%}%}% %{_lastactive}%"
-				#
-				# > Prints island upgrades
-				message "%{_prefix}% %{SB::lang::isupgrades::%{SK::lang::%uuid of player%}%}%"
-				message "%{_prefix}% | %{SB::lang::bc::islandhometitle::%{SK::lang::%uuid of player%}%}%%{_homelevel}% | %{SB::lang::bc::islandhoppertitle::%{SK::lang::%uuid of player%}%}%%{_hopperlevel}% | %{SB::lang::bc::islandsizetitle::%{SK::lang::%uuid of player%}%}%%{_sizelevel}% |"
+        #
+        # > Prints the defined spacer:
+        message "%{SB::config::spacer}%"
+        #
+        # > Prints the header:
+        message "%{_prefix}% %{SB::lang::isinfo::%{SK::lang::%uuid of player%}%}%"
+        #
+        # > Prints the leader of the island:
+        message "%{_prefix}% %{SB::lang::isleader::%{SK::lang::%uuid of player%}%}% %{_uuid}%"
+        #
+        # > Prints the members, if there is at least one member:
+        if size of {_member::*} is not 0:
+          message "%{_prefix}% %{SB::lang::ismember::%{SK::lang::%uuid of player%}%}% %{_member::*}%"
+        #
+        # > Prints the trusted player, if there is at least one trusted player:
+        if size of {_trusted::*} is not 0:
+          message "%{_prefix}% %{SB::lang::istrusted::%{SK::lang::%uuid of player%}%}% %{_trusted::*}%"
+        #
+        # > Prints the island info:
+        message "%{_prefix}% %{SB::lang::isinfolevel::%{SK::lang::%uuid of player%}%}% %{_level}%"
+        #
+        # > Prints the creation date of the island:
+        message "%{_prefix}% %{SB::lang::iscreated::%{SK::lang::%uuid of player%}%}% %{_created}%"
+        #
+        # > Prints the last active date of the island:
+        message "%{_prefix}% %{SB::lang::islastactive::%{SK::lang::%uuid of player%}%}% %{_lastactive}%"
+        #
+        # > Prints island upgrades
+        message "%{_prefix}% %{SB::lang::isupgrades::%{SK::lang::%uuid of player%}%}%"
+        message "%{_prefix}% | %{SB::lang::bc::islandhometitle::%{SK::lang::%uuid of player%}%}%%{_homelevel}% | %{SB::lang::bc::islandhoppertitle::%{SK::lang::%uuid of player%}%}%%{_hopperlevel}% | %{SB::lang::bc::islandsizetitle::%{SK::lang::%uuid of player%}%}%%{_sizelevel}% |"
 
-				#
-				# > Prints the defined spacer:
-				message "%{SB::config::spacer}%"
+        #
+        # > Prints the defined spacer:
+        message "%{SB::config::spacer}%"
 
-		#
-		# > Argument: "generator" ("gen" OR "oregen" OR "oregenerator")
-		# > If a player types in /island generator, his current generator level is displayed
-		# > Actions:
-		# > Gets all the broken blocks and calculates the final level the player is currently on and
-		# > also display a visual appealing status, how far the next level is away. This is done in a function.
-		#
-		else if arg-1 is "generator" OR "gen" OR "oregen" OR "oregenerator":
-			generatorinfo(player)
+    #
+    # > Argument: "generator" ("gen" OR "oregen" OR "oregenerator")
+    # > If a player types in /island generator, his current generator level is displayed
+    # > Actions:
+    # > Gets all the broken blocks and calculates the final level the player is currently on and
+    # > also display a visual appealing status, how far the next level is away. This is done in a function.
+    #
+    else if arg-1 is "generator" OR "gen" OR "oregen" OR "oregenerator":
+      generatorinfo(player)
 
-		#
-		# > Argument: "generator" ("gen" OR "oregen" OR "oregenerator")
-		# > If a player types in /island ores, his current chances are displayed
-		# > Actions:
-		# > Gets all the ore generator chances for the player
-		#
-		else if arg-1 is "ores" OR "ore" OR "orechances" OR "chances":
-			orechancesinfo(player)
+    #
+    # > Argument: "generator" ("gen" OR "oregen" OR "oregenerator")
+    # > If a player types in /island ores, his current chances are displayed
+    # > Actions:
+    # > Gets all the ore generator chances for the player
+    #
+    else if arg-1 is "ores" OR "ore" OR "orechances" OR "chances":
+      orechancesinfo(player)
 
-		#
-		# > Argument: "biome" ("biomes" OR "biom")
-		# > If a player types in /island biome, a biome select menu is opened.
-		# > Actions:
-		# > Opens biome menu
-		else if arg-1 is "biome" OR "biomes" OR "biom":
-			biomemenu(player)
+    #
+    # > Argument: "biome" ("biomes" OR "biom")
+    # > If a player types in /island biome, a biome select menu is opened.
+    # > Actions:
+    # > Opens biome menu
+    else if arg-1 is "biome" OR "biomes" OR "biom":
+      biomemenu(player)
 
-		#
-		# > Argument: "trust"
-		# > If a player types in /island trust, the trusthandler function is called.
-		# > Actions:
-		# > Calls the trusthandler function, which either lists all options, adds someone as
-		# > trusted or removes a trusted user, also can list all trusted users.
-		else if arg-1 is "trust":
-			trusthandler(player,arg-2,arg-3)
+    #
+    # > Argument: "trust"
+    # > If a player types in /island trust, the trusthandler function is called.
+    # > Actions:
+    # > Calls the trusthandler function, which either lists all options, adds someone as
+    # > trusted or removes a trusted user, also can list all trusted users.
+    else if arg-1 is "trust":
+      trusthandler(player,arg-2,arg-3)
 
-		#
-		# > Argument: "upgrade" ("upgrades")
-		# > If a player types in /island upgrade, the islandupgrademenu function is called.
-		# > Actions:
-		# > Calls the islandupgrademenu function, which opens the upgrade menu.
-		else if arg-1 is "upgrade" or "upgrades":
-			islandupgrademenu(player)
-		#
-		# > Argument: "warp" OR "setwarp" OR "delwarp"
-		# > If a player types in /island warp|setwarp|delwarp, the warphandler function is called.
-		# > Actions:
-		# > Calls the warphandler function, which allows to teleport, set and delete warps.
-		else if arg-1 is "warp" or "setwarp" or "delwarp":
-			warphandler(player,arg-1,arg-2)
+    #
+    # > Argument: "upgrade" ("upgrades")
+    # > If a player types in /island upgrade, the islandupgrademenu function is called.
+    # > Actions:
+    # > Calls the islandupgrademenu function, which opens the upgrade menu.
+    else if arg-1 is "upgrade" or "upgrades":
+      islandupgrademenu(player)
+    #
+    # > Argument: "warp" OR "setwarp" OR "delwarp"
+    # > If a player types in /island warp|setwarp|delwarp, the warphandler function is called.
+    # > Actions:
+    # > Calls the warphandler function, which allows to teleport, set and delete warps.
+    else if arg-1 is "warp" or "setwarp" or "delwarp":
+      warphandler(player,arg-1,arg-2)

--- a/SkyBlock/SKYBLOCK.SK/Commands.sk
+++ b/SkyBlock/SKYBLOCK.SK/Commands.sk
@@ -4,7 +4,7 @@
 # > This command contains multible of actions which are meant to be used by an administrator for
 # > administration and moderation purposes.
 command /islandadmin [<text>] [<text>] [<text>] [<text>] [<text>]:
-  permission:  is.admin
+  permission: is.admin
   aliases: /isadmin
   trigger:
     #
@@ -382,7 +382,12 @@ command /island [<text>] [<text=1>] [<text>]:
           set {_level} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::level}
           set {_exp} to {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::exp}
 		  #
-		  # > If there is already a level set for this player, delete the list entry.
+		  # > Check for duplicate entries, if there are any, delete this entry in the list.
+          if {_duplicationcheck::%loop-index%} is set:
+            delete {SB::islvl::%loop-index%}
+          set {_duplicationcheck::%loop-index%} to loop-value
+          #
+          # > If there is already a level set for this player, delete the list entry.
           if {_Level::%{_uuid}%} is set:
             delete {SB::islvl::%loop-index%}
           set {_Level::%{_uuid}%} to {_level}


### PR DESCRIPTION
- Now, the /island info command uses the ```checkislandaccess``` function to get the current island, which is more efficient.
- Changed the tabs of the file to 2 spaces.
- If there are duplicate islands in the ```{SB::islvl::*}``` list, they get deleted. Solved this issue: https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/80