### PR TITLE
Added flag check for redstone

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Events.sk
+++ b/SkyBlock/SKYBLOCK.SK/Events.sk
@@ -79,6 +79,7 @@ on EntityDamageByEntityEvent:
 		set {_allowed} to checkislandaccess({_player},{_l},"EntityDamageByEntityEvent-%{_type}%")
 		if {_allowed} is false:
 			cancel event
+			stop
 	#
 	# > If the damage has been done by an arrow or snowball.
 	if "%{_player}%" is "arrow" or "snowball":
@@ -138,9 +139,18 @@ on PlayerInteractEvent:
 	if {_b} is pressure plate or tripwire:
 		stop
 	#
+	# > Check for the following redstone changes (there is a specific flag for this).
+	if {_b} is repeater or comparator or daylight detector:
+		set {_player} to event.getPlayer()
+		if {_player} is a player:
+			set {_l} to event.getClickedBlock().getLocation()
+			set {_allowed} to checkislandaccess({_player},{_l},"Redstone")
+			if {_allowed} is false:
+				cancel event
+	#
 	# > Only prevent these types of interactions and let others trough,
 	# > this gets called very often, should be very efficient.
-	if {_b} is soil or lever or button or door or trapdoor or fence gate or comparator or repeater or chest or trapped chest or shulker box or anvil or enchanting table or jukebox or furnace or brewing stand or daylight detector or flower pot or hopper or dropper or dispenser:
+	if {_b} is soil or lever or button or door or trapdoor or fence gate or chest or trapped chest or shulker box or anvil or enchanting table or jukebox or furnace or brewing stand or flower pot or hopper or dropper or dispenser:
 		set {_player} to event.getPlayer()
 		if {_player} is a player:
 			set {_l} to event.getClickedBlock().getLocation()

--- a/SkyBlock/SKYBLOCK.SK/Events.sk
+++ b/SkyBlock/SKYBLOCK.SK/Events.sk
@@ -1,11 +1,11 @@
 #
 # > Import some Java classes which are needed to fire some triggers.
 import:
-	org.bukkit.event.player.PlayerArmorStandManipulateEvent
-	org.bukkit.event.entity.EntityDamageByEntityEvent
-	org.bukkit.event.vehicle.VehicleDamageEvent
-	org.bukkit.Location
-	org.bukkit.event.player.PlayerInteractEvent
+  org.bukkit.event.player.PlayerArmorStandManipulateEvent
+  org.bukkit.event.entity.EntityDamageByEntityEvent
+  org.bukkit.event.vehicle.VehicleDamageEvent
+  org.bukkit.Location
+  org.bukkit.event.player.PlayerInteractEvent
 
 #
 # > Events (Triggers) for protection purposes
@@ -16,12 +16,12 @@ import:
 # > Actions:
 # > Checks if the player is allowed to do it, if not, cancel it.
 on PlayerArmorStandManipulateEvent:
-	set {_player} to event.getPlayer()
-	if {_player} is a player:
-		set {_l} to event.getEntity().getLocation()
-		set {_allowed} to checkislandaccess({_player},{_l})
-		if {_allowed} is false:
-			cancel event
+  set {_player} to event.getPlayer()
+  if {_player} is a player:
+    set {_l} to event.getEntity().getLocation()
+    set {_allowed} to checkislandaccess({_player},{_l})
+    if {_allowed} is false:
+      cancel event
 
 #
 # > Event - rightclick
@@ -29,11 +29,11 @@ on PlayerArmorStandManipulateEvent:
 # > Actions:
 # > Checks for some tools which can be placed and if it is allowed to be placed, if not, cancel the event.
 on rightclick:
-	if player's tool is armor stand:
-		set {_l} to location of targeted block
-		set {_allowed} to checkislandaccess(player,{_l})
-		if {_allowed} is not true:
-			cancel event
+  if player's tool is armor stand:
+    set {_l} to location of targeted block
+    set {_allowed} to checkislandaccess(player,{_l})
+    if {_allowed} is not true:
+      cancel event
 
 #
 # > Event - bucket fill
@@ -42,11 +42,11 @@ on rightclick:
 # > If the player is allowed to do this action, cancel the event and then give a island
 # > bound lava bucket out.
 on bucket fill:
-	if target block is lava:
-		set {_allowed} to checkislandaccess(player,event-location)
-		if {_allowed} is not false:
-			cancel event
-			binditem(event-location, player,lava bucket)
+  if target block is lava:
+    set {_allowed} to checkislandaccess(player,event-location)
+    if {_allowed} is not false:
+      cancel event
+      binditem(event-location, player,lava bucket)
 
 #
 # > Event - bucket fill
@@ -55,75 +55,75 @@ on bucket fill:
 # > If the player is allowed to do this action and the bucket is bound to an island,
 # > cancel the event.
 on bucket empty:
-	if player's tool is lava bucket:
-		set {_allowed} to checkislandaccess(player,event-location)
-		if {_allowed} is not false:
-			set {_allowed} to bindcheck(player's tool, player)
-			if {_allowed} is false:
-				cancel event
+  if player's tool is lava bucket:
+    set {_allowed} to checkislandaccess(player,event-location)
+    if {_allowed} is not false:
+      set {_allowed} to bindcheck(player's tool, player)
+      if {_allowed} is false:
+        cancel event
 #
 # > Event - EntityDamageByEntityEvent
 # > If a entity gets damage by a entity, this event is called.
 # > Actions:
 # > Checks if the player is allowed to do it, if not, cancel it.
 on EntityDamageByEntityEvent:
-	set {_player} to event.getDamager()
-	if {_player} is a player:
-		set {_l} to event.getEntity().getLocation()
-		if event.getEntity() is a animal:
-			set {_type} to "animal"
-		else if event.getEntity() is a monster:
-			set {_type} to "monster"
-		else:
-			set {_type} to "entity"
-		set {_allowed} to checkislandaccess({_player},{_l},"EntityDamageByEntityEvent-%{_type}%")
-		if {_allowed} is false:
-			cancel event
-			stop
-	#
-	# > If the damage has been done by an arrow or snowball.
-	if "%{_player}%" is "arrow" or "snowball":
-		#
-		# > Check, if the shooter is a player, allow skeletons to throw arrows like they want.
-		if {_player}.getShooter() is a player:
-			#
-			# > Get the entity type to check if the shooter is allowed to do this.
-			if event.getEntity() is a animal:
-				set {_type} to "animal"
-			#
-			# > If the victim is a player and then check for the pvp setting, if false, cancel the event.
-			else if event.getEntity() is a player:
-				if {SB::config::pvp} is false:
-					cancel event
-					stop
-			#
-			# > If the victim is a monster, set the type to monster.
-			else if event.getEntity() is a monster:
-				set {_type} to "monster"
-			#
-			# > If the victim is something else, set it to "entity".
-			else:
-				set {_type} to "entity"
-			#
-			# > Check, if the shooter is allowed to shoot and check the location of the entity.
-			set {_allowed} to checkislandaccess({_player}.getShooter(),location of event.getEntity(),"EntityDamageByEntityEvent-%{_type}%")
-			#
-			# > If now allowed, cancel the event.
-			if {_allowed} is false:
-				cancel event
-				stop
+  set {_player} to event.getDamager()
+  if {_player} is a player:
+    set {_l} to event.getEntity().getLocation()
+    if event.getEntity() is a animal:
+      set {_type} to "animal"
+    else if event.getEntity() is a monster:
+      set {_type} to "monster"
+    else:
+      set {_type} to "entity"
+    set {_allowed} to checkislandaccess({_player},{_l},"EntityDamageByEntityEvent-%{_type}%")
+    if {_allowed} is false:
+      cancel event
+      stop
+  #
+  # > If the damage has been done by an arrow or snowball.
+  if "%{_player}%" is "arrow" or "snowball":
+    #
+    # > Check, if the shooter is a player, allow skeletons to throw arrows like they want.
+    if {_player}.getShooter() is a player:
+      #
+      # > Get the entity type to check if the shooter is allowed to do this.
+      if event.getEntity() is a animal:
+        set {_type} to "animal"
+      #
+      # > If the victim is a player and then check for the pvp setting, if false, cancel the event.
+      else if event.getEntity() is a player:
+        if {SB::config::pvp} is false:
+          cancel event
+          stop
+      #
+      # > If the victim is a monster, set the type to monster.
+      else if event.getEntity() is a monster:
+        set {_type} to "monster"
+      #
+      # > If the victim is something else, set it to "entity".
+      else:
+        set {_type} to "entity"
+      #
+      # > Check, if the shooter is allowed to shoot and check the location of the entity.
+      set {_allowed} to checkislandaccess({_player}.getShooter(),location of event.getEntity(),"EntityDamageByEntityEvent-%{_type}%")
+      #
+      # > If now allowed, cancel the event.
+      if {_allowed} is false:
+        cancel event
+        stop
 
 # > Event: VehicleDamageEvent
 # > Triggered if a vehicle is damaged, this could be a minecart or a boat.
 # > Actions:
 # > If the attacker is a player, check if the player is allowed to damage the vehicle, if not, cancel it.
 on VehicleDamageEvent:
-	set {_player} to event.getAttacker()
-	if {_player} is a player:
-		set {_l} to event.getVehicle().getLocation()
-		set {_allowed} to checkislandaccess({_player},{_l},"VehicleDamageEvent")
-		if {_allowed} is false:
-			cancel event
+  set {_player} to event.getAttacker()
+  if {_player} is a player:
+    set {_l} to event.getVehicle().getLocation()
+    set {_allowed} to checkislandaccess({_player},{_l},"VehicleDamageEvent")
+    if {_allowed} is false:
+      cancel event
 
 #
 # > Event - PlayerInteractEvent
@@ -131,67 +131,67 @@ on VehicleDamageEvent:
 # > Actions:
 # > Checks if the player is allowed to do it, if not, cancel it. (only if the block is soil)
 on PlayerInteractEvent:
-	#
-	# > Set the interaction block to a local variable.
-	set {_b} to event.getClickedBlock()
-	#
-	# > Since pressure plates might get called often, they dont have to be checked, we stop directly here.
-	if {_b} is pressure plate or tripwire:
-		stop
-	#
-	# > Check for the following redstone changes (there is a specific flag for this).
-	if {_b} is repeater or comparator or daylight detector:
-		set {_player} to event.getPlayer()
-		if {_player} is a player:
-			set {_l} to event.getClickedBlock().getLocation()
-			set {_allowed} to checkislandaccess({_player},{_l},"Redstone")
-			if {_allowed} is false:
-				cancel event
-	#
-	# > Only prevent these types of interactions and let others trough,
-	# > this gets called very often, should be very efficient.
-	if {_b} is soil or lever or button or door or trapdoor or fence gate or chest or trapped chest or shulker box or anvil or enchanting table or jukebox or furnace or brewing stand or flower pot or hopper or dropper or dispenser:
-		set {_player} to event.getPlayer()
-		if {_player} is a player:
-			set {_l} to event.getClickedBlock().getLocation()
-			set {_allowed} to checkislandaccess({_player},{_l},"PlayerInteractEvent",{_b})
-			if {_allowed} is false:
-				cancel event
+  #
+  # > Set the interaction block to a local variable.
+  set {_b} to event.getClickedBlock()
+  #
+  # > Since pressure plates might get called often, they dont have to be checked, we stop directly here.
+  if {_b} is pressure plate or tripwire:
+    stop
+  #
+  # > Check for the following redstone changes (there is a specific flag for this).
+  if {_b} is repeater or comparator or daylight detector:
+    set {_player} to event.getPlayer()
+    if {_player} is a player:
+      set {_l} to event.getClickedBlock().getLocation()
+      set {_allowed} to checkislandaccess({_player},{_l},"Redstone")
+      if {_allowed} is false:
+        cancel event
+  #
+  # > Only prevent these types of interactions and let others trough,
+  # > this gets called very often, should be very efficient.
+  if {_b} is soil or lever or button or door or trapdoor or fence gate or chest or trapped chest or shulker box or anvil or enchanting table or jukebox or furnace or brewing stand or flower pot or hopper or dropper or dispenser:
+    set {_player} to event.getPlayer()
+    if {_player} is a player:
+      set {_l} to event.getClickedBlock().getLocation()
+      set {_allowed} to checkislandaccess({_player},{_l},"PlayerInteractEvent",{_b})
+      if {_allowed} is false:
+        cancel event
 
-	#
-	# > If there is a potted plant, we check that kind of stuff with a text for now,
-	# > since almost every plant can be placed in a flower pot, this is faster than checking
-	# > through all types of flower pots.
-	if "%{_b}%" contains "potted" or "flower pot with":
-		set {_player} to event.getPlayer()
-		if {_player} is a player:
-			set {_l} to event.getClickedBlock().getLocation()
-			set {_allowed} to checkislandaccess({_player},{_l},"build")
-			if {_allowed} is false:
-				cancel event
+  #
+  # > If there is a potted plant, we check that kind of stuff with a text for now,
+  # > since almost every plant can be placed in a flower pot, this is faster than checking
+  # > through all types of flower pots.
+  if "%{_b}%" contains "potted" or "flower pot with":
+    set {_player} to event.getPlayer()
+    if {_player} is a player:
+      set {_l} to event.getClickedBlock().getLocation()
+      set {_allowed} to checkislandaccess({_player},{_l},"build")
+      if {_allowed} is false:
+        cancel event
 
-	
+  
 #
 # > Event - place
 # > Triggered, if the player places a block.
 # > Actions:
 # > Checks if the player is allowed to do it, if not, cancel it.
 on place:
-	set {_allowed} to checkislandaccess(player,location of event-block,"build")
-	#
-	# > If the player is allowed to build and the event-block is also a hopper,
-	# > check, run the hoppercounter function.
-	if event-block is hopper:
-		if {_allowed} is true:
-			set {_allowed} to hoppercounter(player, "place")
-	#
-	# > If the placed block is dirt, grass or farmland, check if it is bound to
-	# > an specific island.
-	if event-block is dirt or grass or farmland or obsidian or grass path:
-		if {_allowed} is true:
-			set {_allowed} to bindcheck(player's tool, player)
-	if {_allowed} is false:
-		cancel event
+  set {_allowed} to checkislandaccess(player,location of event-block,"build")
+  #
+  # > If the player is allowed to build and the event-block is also a hopper,
+  # > check, run the hoppercounter function.
+  if event-block is hopper:
+    if {_allowed} is true:
+      set {_allowed} to hoppercounter(player, "place")
+  #
+  # > If the placed block is dirt, grass or farmland, check if it is bound to
+  # > an specific island.
+  if event-block is dirt or grass or farmland or obsidian or grass path:
+    if {_allowed} is true:
+      set {_allowed} to bindcheck(player's tool, player)
+  if {_allowed} is false:
+    cancel event
 
 #
 # > Event - place
@@ -199,26 +199,26 @@ on place:
 # > Actions:
 # > Checks if the player is allowed to do it, if not, cancel it.
 on break:
-	set {_allowed} to checkislandaccess(player,location of event-block,"build")
-	#
-	# > If the player is allowed to build and the event-block is also a hopper,
-	# > check, run the hoppercounter function.
-	if event-block is hopper:
-		if {_allowed} is true:
-			set {_allowed} to hoppercounter(player, "break")
-	if {_allowed} is false:
-		cancel event
-	if {_allowed} is true:
-		#
-		# > If the player is allowed to break the block, check if the block is
-		# > dirt, grass or farmland and then add a island binding to it, if the
-		# > island is below level 100.
-		if event-block is dirt or grass or farmland or grass path:
-			cancel event
-			binditem(event-location, player,dirt)
-		if event-block is obsidian:
-			cancel event
-			binditem(event-location, player,obsidian)
+  set {_allowed} to checkislandaccess(player,location of event-block,"build")
+  #
+  # > If the player is allowed to build and the event-block is also a hopper,
+  # > check, run the hoppercounter function.
+  if event-block is hopper:
+    if {_allowed} is true:
+      set {_allowed} to hoppercounter(player, "break")
+  if {_allowed} is false:
+    cancel event
+  if {_allowed} is true:
+    #
+    # > If the player is allowed to break the block, check if the block is
+    # > dirt, grass or farmland and then add a island binding to it, if the
+    # > island is below level 100.
+    if event-block is dirt or grass or farmland or grass path:
+      cancel event
+      binditem(event-location, player,dirt)
+    if event-block is obsidian:
+      cancel event
+      binditem(event-location, player,obsidian)
 
 #
 # > Event - rightclick on a entity
@@ -226,95 +226,95 @@ on break:
 # > Actions:
 # > Checks if the player is allowed to do it, if not, cancel it.
 on rightclick on entity:
-	if "%event-entity%" contains "minecart" or "boat":
-		set {_allowed} to checkislandaccess(player,location of event-entity,"vehicle-click")
-	else:
-		set {_allowed} to checkislandaccess(player,location of event-entity,"entity-click")
-	if {_allowed} is false:
-		cancel event
+  if "%event-entity%" contains "minecart" or "boat":
+    set {_allowed} to checkislandaccess(player,location of event-entity,"vehicle-click")
+  else:
+    set {_allowed} to checkislandaccess(player,location of event-entity,"entity-click")
+  if {_allowed} is false:
+    cancel event
 
 #Disable 1.13 phantoms:
 #todo check from config if enabled or disabled:
 on spawn of a phantom: 
-	cancel event
+  cancel event
 
 #
 # > For now, we want to not allow people to change the world into the nether,
 # > the nether can be turned on in the config.sk but this is very unbalanced.
 on world change:
-	set {_prefix} to {SB::lang::prefix::%{SK::lang::%uuid of player%}%}
-	if player has permission "%{SB::config::buildpermission}%":
-		if event-world is "%{SB::config::world}%":
-			make player execute command "/is spawn"
-		stop
-	if "%event-world%" contains "nether":
-		if {SB::config::portalenter} is "false":
-			make player execute command "/is home"
-			actionload(player, {SB::lang::nonether::%{SK::lang::%uuid of player%}%})
-	#If player changes the world and is in the Island world, teleport the player back to the home to make sure player is not falling to death
-	if event-world is "%{SB::config::world}%":
-		make player execute command "/is home"
+  set {_prefix} to {SB::lang::prefix::%{SK::lang::%uuid of player%}%}
+  if player has permission "%{SB::config::buildpermission}%":
+    if event-world is "%{SB::config::world}%":
+      make player execute command "/is spawn"
+    stop
+  if "%event-world%" contains "nether":
+    if {SB::config::portalenter} is "false":
+      make player execute command "/is home"
+      actionload(player, {SB::lang::nonether::%{SK::lang::%uuid of player%}%})
+  #If player changes the world and is in the Island world, teleport the player back to the home to make sure player is not falling to death
+  if event-world is "%{SB::config::world}%":
+    make player execute command "/is home"
 
 #On player death, save the hunger bar to reset it after the respawn, this makes food worth more
 on death of player:
-	set {_p} to victim
-	if {_p} is a player:
-		if {_p} is online:
-			if {SB::config::preventhungerreset} is true:
-				set {SB::hunger::%{_p}%} to hunger of {_p}
+  set {_p} to victim
+  if {_p} is a player:
+    if {_p} is online:
+      if {SB::config::preventhungerreset} is true:
+        set {SB::hunger::%{_p}%} to hunger of {_p}
 on respawn:
-	wait a tick
-	if {SB::player::%uuid of player%::island::bedrock} is set:
-		make player execute command "/is home"
-	else:
-		make player execute command "/is spawn"
-	if {SB::config::preventhungerreset} is true:
-		set hunger of player to {SB::hunger::%player%}
+  wait a tick
+  if {SB::player::%uuid of player%::island::bedrock} is set:
+    make player execute command "/is home"
+  else:
+    make player execute command "/is spawn"
+  if {SB::config::preventhungerreset} is true:
+    set hunger of player to {SB::hunger::%player%}
 
 on damage:
-	set {_prefix} to {SB::lang::prefix::%{Language::%attacker%}%}
-	set {_a} to {SB::lang::nopvp::%{Language::%attacker%}%}
-	if victim is a player:
-		if {SB::invincible::%victim%} is set:
-			cancel event
-	if attacker has permission "%{SB::config::buildpermission}%":
-		stop
-	if {SB::config::pvp} is false:
-		if attacker is a player:
-			if victim is a player:
-				actionload(attacker, {_a})
-				cancel event
-			stop
-	#todo double check this part, something doesnt work right here:
-	else:
-		if {SB::player::%uuid of attacker%::island::bedrock} is not set:
-			cancel event
-			actionload(attacker, {_a})
-		else:
-			set {_allowed} to checkislandaccess(attacker,location of attacker)
-			if {_allowed} is false:
-				cancel event
-				actionload(attacker, {_a})
+  set {_prefix} to {SB::lang::prefix::%{Language::%attacker%}%}
+  set {_a} to {SB::lang::nopvp::%{Language::%attacker%}%}
+  if victim is a player:
+    if {SB::invincible::%victim%} is set:
+      cancel event
+  if attacker has permission "%{SB::config::buildpermission}%":
+    stop
+  if {SB::config::pvp} is false:
+    if attacker is a player:
+      if victim is a player:
+        actionload(attacker, {_a})
+        cancel event
+      stop
+  #todo double check this part, something doesnt work right here:
+  else:
+    if {SB::player::%uuid of attacker%::island::bedrock} is not set:
+      cancel event
+      actionload(attacker, {_a})
+    else:
+      set {_allowed} to checkislandaccess(attacker,location of attacker)
+      if {_allowed} is false:
+        cancel event
+        actionload(attacker, {_a})
 
 on ignition:
-	#todo add in config to ask:
-	#players allowed to set fire, true, false
-	#should fire spread, true, false
-	if player is set:
-		stop
-	cancel event
+  #todo add in config to ask:
+  #players allowed to set fire, true, false
+  #should fire spread, true, false
+  if player is set:
+    stop
+  cancel event
 
 # > Event: on explode
 # > Actions:
 # > Triggered on an explosion, checks for the nearest player and then check if the explosion is allowed.
 on explode:
-	set {_l} to event-location
-	loop players in radius 30 of {_l}:
-		set {_player} to loop-player
-		stop loop
-	set {_allowed} to checkislandaccess({_player},{_l},"Explode")
-	if {_allowed} is false:
-		cancel event
+  set {_l} to event-location
+  loop players in radius 30 of {_l}:
+    set {_player} to loop-player
+    stop loop
+  set {_allowed} to checkislandaccess({_player},{_l},"Explode")
+  if {_allowed} is false:
+    cancel event
 
 # > Event: on script load
 # > Actions:
@@ -322,58 +322,58 @@ on explode:
 # > and also goes trough islands which should be deleted, all island locations are saved within
 # > the {deleteisland.1::*} and {deleteisland.2::*} array.
 on script load:
-	set {SB::searchprocess} to false
-	delete {SB::searchis::*}
-	delete {SB::hunger::*}
-	delete {SB::calcstatus::*}
-	delete {SB::actionload::*}
+  set {SB::searchprocess} to false
+  delete {SB::searchis::*}
+  delete {SB::hunger::*}
+  delete {SB::calcstatus::*}
+  delete {SB::actionload::*}
 
-	loop {deleteisland.1::*}:
-		wait 0.5 seconds
-		set {_loc1} to loop-value
-		set {_loc2} to {deleteisland.2::%loop-index%}
+  loop {deleteisland.1::*}:
+    wait 0.5 seconds
+    set {_loc1} to loop-value
+    set {_loc2} to {deleteisland.2::%loop-index%}
 
-		loop blocks within {_loc1} to {_loc2}:
-			if loop-block is chest or trapped chest:
-				clear loop-block's inventory
-			if loop-block is not air:
-				set loop-block to air
-				add 1 to {_i}
-			if {_i} is 500:
-				wait 1 tick
-				delete {_i}
-		delete {deleteisland.1::%loop-index%}
-		delete {deleteisland.2::%loop-index%}
-	delete {SB::ISDELPROCESS}
- 	#
-	# > To prevent any data being kept here, delete it again completly:
-	delete {deleteisland.1::*}
-	delete {deleteisland.2::*}
+    loop blocks within {_loc1} to {_loc2}:
+      if loop-block is chest or trapped chest:
+        clear loop-block's inventory
+      if loop-block is not air:
+        set loop-block to air
+        add 1 to {_i}
+      if {_i} is 500:
+        wait 1 tick
+        delete {_i}
+    delete {deleteisland.1::%loop-index%}
+    delete {deleteisland.2::%loop-index%}
+  delete {SB::ISDELPROCESS}
+   #
+  # > To prevent any data being kept here, delete it again completly:
+  delete {deleteisland.1::*}
+  delete {deleteisland.2::*}
 
-	#
-	# > If we're done with deleting islands, also double check there is not a level entry left.
-	# > If there is one left, delete it and delete all variables to the island.
-	#
-	loop {SB::islvl::*}:
-		set {_loc::*} to loop-index split at "_"
-		set {_loc::1} to {_loc::1} parsed as number
-		set {_loc::2} to {_loc::2} parsed as number
-		set {_loc::3} to {_loc::3} parsed as number
-		set {_bedrock} to location at {_loc::1}, {_loc::2}, {_loc::3} in "%{SB::config::world}%" parsed as world
-		if block at {_bedrock} is air:
-			delete {SB::islvl::%loop-index%}
-			delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::leader}
-			delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::level}
-			delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::exp}
-			delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::created}
-	#
-	# > If we're done, allow players back on the server by disabling the whitelist.
-	#
-	execute console command "/whitelist off"
+  #
+  # > If we're done with deleting islands, also double check there is not a level entry left.
+  # > If there is one left, delete it and delete all variables to the island.
+  #
+  loop {SB::islvl::*}:
+    set {_loc::*} to loop-index split at "_"
+    set {_loc::1} to {_loc::1} parsed as number
+    set {_loc::2} to {_loc::2} parsed as number
+    set {_loc::3} to {_loc::3} parsed as number
+    set {_bedrock} to location at {_loc::1}, {_loc::2}, {_loc::3} in "%{SB::config::world}%" parsed as world
+    if block at {_bedrock} is air:
+      delete {SB::islvl::%loop-index%}
+      delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::leader}
+      delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::level}
+      delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::exp}
+      delete {SB::island::%{_loc::1}%_%{_loc::2}%_%{_loc::3}%::created}
+  #
+  # > If we're done, allow players back on the server by disabling the whitelist.
+  #
+  execute console command "/whitelist off"
 
 on script unload:
-	execute console command "/whitelist on"
-	set {SB::ISDELPROCESS} to true
+  execute console command "/whitelist on"
+  set {SB::ISDELPROCESS} to true
 
 # > Event: join
 # > Triggered once a player enters the server
@@ -381,32 +381,32 @@ on script unload:
 # > Makes the player invincible, checks if the user has been kicked from an island
 # > and also sets the lastactive state to now to prevent purge of the island.
 on join:
-	set {SB::invincible::%player%} to 1
-	wait a tick
-	#todo check for default language in config.sk if there is "custom" choosen, let the user choose, if there is "api" choosen, use a api or database which has to be added.
-	if {SK::lang::%uuid of player%} is not set:
-		set {SK::lang::%uuid of player%} to "de"
-	set {_uuid} to uuid of player
-	if {Leave.%{_uuid}%} is set:
-		delete {Leave.%uuid of player%}
-		leaveisland(player, "member")
-		make player execute "/is leave"
-		send "%{SB::lang::deletekickmember::%{SK::lang::%uuid of player%}%}%"
-		
-	#
-	# > Set the last activity of the island the player is on to now
-	set {_bedrock} to {SB::player::%uuid of player%::island::bedrock}
-	if {_bedrock} is set:
-		set {_l::1} to x-coord of {_bedrock}
-		set {_l::2} to y-coord of {_bedrock}
-		set {_l::3} to z-coord of {_bedrock}
-		set {SB::island::%{_l::1}%_%{_l::2}%_%{_l::3}%::lastactive} to now
-	wait 5 seconds
-	delete {SB::invincible::%player%} 
-	
+  set {SB::invincible::%player%} to 1
+  wait a tick
+  #todo check for default language in config.sk if there is "custom" choosen, let the user choose, if there is "api" choosen, use a api or database which has to be added.
+  if {SK::lang::%uuid of player%} is not set:
+    set {SK::lang::%uuid of player%} to "de"
+  set {_uuid} to uuid of player
+  if {Leave.%{_uuid}%} is set:
+    delete {Leave.%uuid of player%}
+    leaveisland(player, "member")
+    make player execute "/is leave"
+    send "%{SB::lang::deletekickmember::%{SK::lang::%uuid of player%}%}%"
+    
+  #
+  # > Set the last activity of the island the player is on to now
+  set {_bedrock} to {SB::player::%uuid of player%::island::bedrock}
+  if {_bedrock} is set:
+    set {_l::1} to x-coord of {_bedrock}
+    set {_l::2} to y-coord of {_bedrock}
+    set {_l::3} to z-coord of {_bedrock}
+    set {SB::island::%{_l::1}%_%{_l::2}%_%{_l::3}%::lastactive} to now
+  wait 5 seconds
+  delete {SB::invincible::%player%} 
+  
 on connect:
-	set {SK::lang::%uuid of player%} to "de"
-	set {_prefix} to {SB::lang::prefix::%{SK::lang::%uuid of player%}%}
-	if {SB::ISDELPROCESS} is set:
-		if player doesn't have permission "%{SB::config::buildpermission}%":
-			kick player due to "%{_prefix}% %{SB::lang::delismsg::%{SK::lang::%uuid of player%}%}%"
+  set {SK::lang::%uuid of player%} to "de"
+  set {_prefix} to {SB::lang::prefix::%{SK::lang::%uuid of player%}%}
+  if {SB::ISDELPROCESS} is set:
+    if player doesn't have permission "%{SB::config::buildpermission}%":
+      kick player due to "%{_prefix}% %{SB::lang::delismsg::%{SK::lang::%uuid of player%}%}%"

--- a/SkyBlock/SKYBLOCK.SK/Functions/checkislandaccess.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/checkislandaccess.sk
@@ -288,6 +288,14 @@ function checkflagevent(x:number,y:number,z:number,event:text,playertype:text,bl
       if {SB::config::defaultisflag::%{_playertype}%::explosion} is set:
         return {SB::config::defaultisflag::%{_playertype}%::explosion}
   #
+  # > This flag is for redstone tools, like comparators and repeaters.
+  else if {_event} is "Redstone":
+    if {SB::island::%{_x}%_%{_y}%_%{_z}%::flag::%{_playertype}%::redstone} is set:
+      return {SB::island::%{_x}%_%{_y}%_%{_z}%::flag::%{_playertype}%::redstone}
+    else:
+      if {SB::config::defaultisflag::%{_playertype}%::redstone} is set:
+        return {SB::config::defaultisflag::%{_playertype}%::redstone}
+  #
   # > This flag is for the public home trough /island home [<player>] [<home>]
   else if {_event} is "Home":
     if {SB::island::%{_x}%_%{_y}%_%{_z}%::flag::%{_playertype}%::publichome} is set:

--- a/SkyBlock/config.sk
+++ b/SkyBlock/config.sk
@@ -1,497 +1,513 @@
 on load:
-	loadconfig()
+  loadconfig()
 #
 # SKYBLOCK.SK CONFIGURATION
 # Configurate most of the skript parts here easily
 # You can also edit the skripts itself like you want
 #
 
-	# Set the World name of the Server:
-	set {SB::config::world} to "ASkyBlock"
+  # Set the World name of the Server:
+  set {SB::config::world} to "ASkyBlock"
 
-	# Island storage type (Use either Schematic or Structure):
-	set {SB::config::isstorage} to "Structure"
+  # Island storage type (Use either Schematic or Structure):
+  set {SB::config::isstorage} to "Structure"
 
-	# Set where the players should spawn, change x, y, z to your desired location:
-	set {SB::config::spawn} to location at 20.0, 87.0, 81.5 in "%{SB::config::world}%" parsed as world
-	set {SB::config::spawn}'s pitch to 0
-	set {SB::config::spawn}'s yaw to -95
+  # Set where the players should spawn, change x, y, z to your desired location:
+  set {SB::config::spawn} to location at 20.0, 87.0, 81.5 in "%{SB::config::world}%" parsed as world
+  set {SB::config::spawn}'s pitch to 0
+  set {SB::config::spawn}'s yaw to -95
 
-	# How much distance should be between islands (100 means 200x200 islands)
-	set {SB::config::distance} to 100
+  # How much distance should be between islands (100 means 200x200 islands)
+  set {SB::config::distance} to 100
 
-	# Default size of the island, set it to the distance like above to make it as big as the distance is.
-	# > Do not change the value once you have islands, since it messes up existing islands.
-	# Set it to the same amount as the distance to disable this feature.
-	set {SB::config::defaultsize} to 95
+  # Default size of the island, set it to the distance like above to make it as big as the distance is.
+  # > Do not change the value once you have islands, since it messes up existing islands.
+  # Set it to the same amount as the distance to disable this feature.
+  set {SB::config::defaultsize} to 95
 
-	#
-	# > Set a island level until which dirt, grass and farmland blocks should be bound to the
-	# > island to prevent island creation abuse.
-	set {SB::config::binduntillevel} to 100
+  #
+  # > Set a island level until which dirt, grass and farmland blocks should be bound to the
+  # > island to prevent island creation abuse.
+  set {SB::config::binduntillevel} to 100
 
-	#
-	# > The default amount of hoppers, the player is allowed to place until
-	# > the placement of hoppers is canceled.
-	set {SB::config::starthopper} to 50
+  #
+  # > The default amount of hoppers, the player is allowed to place until
+  # > the placement of hoppers is canceled.
+  set {SB::config::starthopper} to 50
 
-	#
-	# > The maximum amount of hoppers, the player is allowed to place once the
-	# > hopper upgrade is upgraded to the level 5. 
-	set {SB::config::maxhopper} to 400
+  #
+  # > The maximum amount of hoppers, the player is allowed to place once the
+  # > hopper upgrade is upgraded to the level 5. 
+  set {SB::config::maxhopper} to 400
 
-	#
-	# > The default amount of homes the island has to use.
-	set {SB::config::starthomes} to 1
+  #
+  # > The default amount of homes the island has to use.
+  set {SB::config::starthomes} to 1
 
-	#
-	# > The maximum amount of homes, once the island hits home upgrade level 5.
-	set {SB::config::maxhomes} to 6
+  #
+  # > The maximum amount of homes, once the island hits home upgrade level 5.
+  set {SB::config::maxhomes} to 6
 
-	# If the default island size is smaller than the distance between players, you can enable island upgrades,
-	# these are always cut into 5 upgrade packs which are calculated for the island upgrade menu.
-	set {SB::config::islandupgrades} to true
+  # If the default island size is smaller than the distance between players, you can enable island upgrades,
+  # these are always cut into 5 upgrade packs which are calculated for the island upgrade menu.
+  set {SB::config::islandupgrades} to true
 
-	# On which height should islands be created
-	set {SB::config::height} to 100.5
+  # On which height should islands be created
+  set {SB::config::height} to 100.5
 
-	# Set the protection border between islands, 0 = no border:
-	# With a border of 0, 
-	set {SB::config::protect} to 0
+  # Set the protection border between islands, 0 = no border:
+  # With a border of 0, 
+  set {SB::config::protect} to 0
 
-	# Cooldown, how long to wait until the invite is no longer valid:
-	set {SB::config::invitecooldown} to 30
+  # Cooldown, how long to wait until the invite is no longer valid:
+  set {SB::config::invitecooldown} to 30
 
-	# Delete Cooldown - The user has to wait at least this time to delete a newly created island:
-	set {SB::config::deletecooldown} to 30 minutes
+  # Delete Cooldown - The user has to wait at least this time to delete a newly created island:
+  set {SB::config::deletecooldown} to 30 minutes
 
-	# Permission to build everywhere:
-	set {SB::config::buildpermission} to "is.admin"
+  # Permission to build everywhere:
+  set {SB::config::buildpermission} to "is.admin"
 
-	# Are players allowed to enter portals? true = yes, false = no:
-	set {SB::config::portalenter} to false
+  # Are players allowed to enter portals? true = yes, false = no:
+  set {SB::config::portalenter} to false
 
-	# Only allow elytra in own skyblock island? true = yes, false = everywhere
-	set {SB::config::elytra} to true
+  # Only allow elytra in own skyblock island? true = yes, false = everywhere
+  set {SB::config::elytra} to true
 
-	# Enable pvp: true = yes, false = no:
-	set {SB::config::pvp} to false
-
-
-	# Prevent hunger reset on death: true = yes, false = no:
-	set {SB::config::preventhungerreset} to true
+  # Enable pvp: true = yes, false = no:
+  set {SB::config::pvp} to false
 
 
-	#Set a cooldown for /is calc level calculation
-	set {SB::config::calccooldown} to 30 minutes
+  # Prevent hunger reset on death: true = yes, false = no:
+  set {SB::config::preventhungerreset} to true
 
-	# 
-	# > Default Flags
-	# > Change the default flags for islands:
 
-	#
-	# > Changeable Flags
-	# > Allow your players to toggle the flags for their island. True = allowed, false = denied.
-	set {SB::config::toggleflags} to true
+  #Set a cooldown for /is calc level calculation
+  set {SB::config::calccooldown} to 30 minutes
 
-	#
-	# > Default Flags for player islands (foreign flags):
-	#
-	# > Explosions. True = allowed, false = denied.
-	set {SB::config::defaultisflag::foreign::explosion} to false
-	#
-	# > Let users use buttons. True = allowed, false = denied.
-	set {SB::config::defaultisflag::foreign::button} to false
-	#
-	# > Let users use the doors. True = allowed, false = denied.
-	set {SB::config::defaultisflag::foreign::door} to false
-	#
-	# > Damage on entities like mobs, animals or item frames. True = allowed, false = denied.
-	# > Damage on mobs
-	set {SB::config::defaultisflag::foreign::mob-damage} to false
-	#
-	# > Damage on animals
-	set {SB::config::defaultisflag::foreign::animal-damage} to false
-	#
-	# > Interact with vehicles. True = allowed, false = denied.
-	set {SB::config::defaultisflag::foreign::interact-vehicle} to false
-	#
-	# > Allow others to visit the island. True = allowed, false = denied.
-	set {SB::config::defaultisflag::foreign::publichome} to false
-	#
-	# > Allow others to build on the island. True = allowed, false = denied.
-	set {SB::config::defaultisflag::foreign::build} to false
-	#
-	# > Allow others to access to chests. True = allowed, false = denied.
-	set {SB::config::defaultisflag::foreign::chest} to false
-	#
-	# > Allow others to click on the entitiy. True = allowed, false = denied.
-	set {SB::config::defaultisflag::foreign::entityclick} to false
+  # 
+  # > Default Flags
+  # > Change the default flags for islands:
 
-	#
-	# > Default Flags for player islands (trusted flags):
-	#
-	# > Explosions. True = allowed, false = denied.
-	set {SB::config::defaultisflag::trusted::explosion} to false
-	#
-	# > Let users use buttons. True = allowed, false = denied.
-	set {SB::config::defaultisflag::trusted::button} to true
-	#
-	# > Let users use the doors. True = allowed, false = denied.
-	set {SB::config::defaultisflag::trusted::door} to true
-	#
-	# > Damage on entities like mobs, animals or item frames. True = allowed, false = denied.
-	# > Damage on mobs
-	set {SB::config::defaultisflag::trusted::mob-damage} to true
-	#
-	# > Damage on animals
-	set {SB::config::defaultisflag::trusted::animal-damage} to true
-	#
-	# > Interact with vehicles. True = allowed, false = denied.
-	set {SB::config::defaultisflag::trusted::interact-vehicle} to true
-	#
-	# > Allow others to visit the island. True = allowed, false = denied.
-	set {SB::config::defaultisflag::trusted::publichome} to true
-	#
-	# > Allow others to build on the island. True = allowed, false = denied.
-	set {SB::config::defaultisflag::trusted::build} to false
-	#
-	# > Allow others to access to chests. True = allowed, false = denied.
-	set {SB::config::defaultisflag::trusted::chest} to false
-	#
-	# > Allow others to click on the entitiy. True = allowed, false = denied.
-	set {SB::config::defaultisflag::trusted::entityclick} to false
+  #
+  # > Changeable Flags
+  # > Allow your players to toggle the flags for their island. True = allowed, false = denied.
+  set {SB::config::toggleflags} to true
 
-	#
-	# > Default Flags for player islands (foreign flags):
-	#
-	# > Explosions. True = allowed, false = denied.
-	set {SB::config::defaultisflag::member::explosion} to false
-	#
-	# > Let users use buttons. True = allowed, false = denied.
-	set {SB::config::defaultisflag::member::button} to true
-	#
-	# > Let users use the doors. True = allowed, false = denied.
-	set {SB::config::defaultisflag::member::door} to true
-	#
-	# > Damage on entities like mobs, animals or item frames. True = allowed, false = denied.
-	# > Damage on mobs
-	set {SB::config::defaultisflag::member::mob-damage} to true
-	#
-	# > Damage on animals
-	set {SB::config::defaultisflag::member::animal-damage} to true
-	#
-	# > Interact with vehicles. True = allowed, false = denied.
-	set {SB::config::defaultisflag::member::interact-vehicle} to true
-	#
-	# > Allow others to visit the island. True = allowed, false = denied.
-	set {SB::config::defaultisflag::member::publichome} to true
-	#
-	# > Allow others to build on the island. True = allowed, false = denied.
-	set {SB::config::defaultisflag::member::build} to true
-	#
-	# > Allow others to access to chests. True = allowed, false = denied.
-	set {SB::config::defaultisflag::member::chest} to false
-	#
-	# > Allow others to click on the entitiy. True = allowed, false = denied.
-	set {SB::config::defaultisflag::member::entityclick} to false
+  #
+  # > Default Flags for player islands (foreign flags):
+  #
+  # > Explosions. True = allowed, false = denied.
+  set {SB::config::defaultisflag::foreign::explosion} to false
+  #
+  # > Let users use buttons. True = allowed, false = denied.
+  set {SB::config::defaultisflag::foreign::button} to false
+  #
+  # > Let users use the doors. True = allowed, false = denied.
+  set {SB::config::defaultisflag::foreign::door} to false
+  #
+  # > Damage on entities like mobs, animals or item frames. True = allowed, false = denied.
+  # > Damage on mobs
+  set {SB::config::defaultisflag::foreign::mob-damage} to false
+  #
+  # > Damage on animals
+  set {SB::config::defaultisflag::foreign::animal-damage} to false
+  #
+  # > Interact with vehicles. True = allowed, false = denied.
+  set {SB::config::defaultisflag::foreign::interact-vehicle} to false
+  #
+  # > Allow others to visit the island. True = allowed, false = denied.
+  set {SB::config::defaultisflag::foreign::publichome} to false
+  #
+  # > Allow others to build on the island. True = allowed, false = denied.
+  set {SB::config::defaultisflag::foreign::build} to false
+  #
+  # > Allow others to access to chests. True = allowed, false = denied.
+  set {SB::config::defaultisflag::foreign::chest} to false
+  #
+  # > Allow others to click on the entitiy. True = allowed, false = denied.
+  set {SB::config::defaultisflag::foreign::entityclick} to false
+  #
+  # > Allow others to change redstone tools like redstone repeaters. True = allowed, false = denied.
+  set {SB::config::defaultisflag::foreign::redstone} to false
 
-	#
-	# > Flags for not inhabited islands:
-	# > Islands like the lobby island or currently not used islands
-	#
-	# > Explosions. True = allowed, false = denied.
-	set {SB::config::defaultlobbyflag::explosion} to false
-	#
-	# > Explosions. True = allowed, false = denied.
-	set {SB::config::defaultlobbyflag::mob-spawning} to false
-	#
-	# > Let players use buttons. True = allowed, false = denied.
-	set {SB::config::defaultlobbyflag::button} to true
-	#
-	# > Let players use the doors. True = allowed, false = denied.
-	set {SB::config::defaultlobbyflag::door} to true
-	#
-	# > Damage on entities like mobs, animals or item frames. True = allowed, false = denied.
-	# > Damage on mobs
-	set {SB::config::defaultlobbyflag::mob-damage} to true
-	#
-	# > Damage on animals
-	set {SB::config::defaultlobbyflag::animal-damage} to false
-	#
-	# > Damage on item frames
-	set {SB::config::defaultlobbyflag::itemframe-damage} to false
+  #
+  # > Default Flags for player islands (trusted flags):
+  #
+  # > Explosions. True = allowed, false = denied.
+  set {SB::config::defaultisflag::trusted::explosion} to false
+  #
+  # > Let users use buttons. True = allowed, false = denied.
+  set {SB::config::defaultisflag::trusted::button} to true
+  #
+  # > Let users use the doors. True = allowed, false = denied.
+  set {SB::config::defaultisflag::trusted::door} to true
+  #
+  # > Damage on entities like mobs, animals or item frames. True = allowed, false = denied.
+  # > Damage on mobs
+  set {SB::config::defaultisflag::trusted::mob-damage} to true
+  #
+  # > Damage on animals
+  set {SB::config::defaultisflag::trusted::animal-damage} to true
+  #
+  # > Interact with vehicles. True = allowed, false = denied.
+  set {SB::config::defaultisflag::trusted::interact-vehicle} to true
+  #
+  # > Allow others to visit the island. True = allowed, false = denied.
+  set {SB::config::defaultisflag::trusted::publichome} to true
+  #
+  # > Allow others to build on the island. True = allowed, false = denied.
+  set {SB::config::defaultisflag::trusted::build} to false
+  #
+  # > Allow others to access to chests. True = allowed, false = denied.
+  set {SB::config::defaultisflag::trusted::chest} to false
+  #
+  # > Allow others to click on the entitiy. True = allowed, false = denied.
+  set {SB::config::defaultisflag::trusted::entityclick} to false
+  #
+  # > Allow others to change redstone tools like redstone repeaters. True = allowed, false = denied.
+  set {SB::config::defaultisflag::trusted::redstone} to true
 
-	#
-	# > Interact with vehicles. True = allowed, false = denied.
-	set {SB::config::defaultlobbyflag::interact-vehicle} to false
+  #
+  # > Default Flags for player islands (foreign flags):
+  #
+  # > Explosions. True = allowed, false = denied.
+  set {SB::config::defaultisflag::member::explosion} to false
+  #
+  # > Let users use buttons. True = allowed, false = denied.
+  set {SB::config::defaultisflag::member::button} to true
+  #
+  # > Let users use the doors. True = allowed, false = denied.
+  set {SB::config::defaultisflag::member::door} to true
+  #
+  # > Damage on entities like mobs, animals or item frames. True = allowed, false = denied.
+  # > Damage on mobs
+  set {SB::config::defaultisflag::member::mob-damage} to true
+  #
+  # > Damage on animals
+  set {SB::config::defaultisflag::member::animal-damage} to true
+  #
+  # > Interact with vehicles. True = allowed, false = denied.
+  set {SB::config::defaultisflag::member::interact-vehicle} to true
+  #
+  # > Allow others to visit the island. True = allowed, false = denied.
+  set {SB::config::defaultisflag::member::publichome} to true
+  #
+  # > Allow others to build on the island. True = allowed, false = denied.
+  set {SB::config::defaultisflag::member::build} to true
+  #
+  # > Allow others to access to chests. True = allowed, false = denied.
+  set {SB::config::defaultisflag::member::chest} to true
+  #
+  # > Allow others to click on the entitiy. True = allowed, false = denied.
+  set {SB::config::defaultisflag::member::entityclick} to true
+  #
+  # > Allow others to change redstone tools like redstone repeaters. True = allowed, false = denied.
+  set {SB::config::defaultisflag::member::redstone} to true
 
-	#
-	# > Color Scheme
-	# > Change this to match the colors with your corporate identity
-	#
-	set {SB::config::color::primary::1} to "&6"
-	set {SB::config::color::primary::2} to "&e"
-	set {SB::config::color::secondary::2} to "&7"
-	set {SB::config::color::background::1} to "&8"
 
-	#
-	# > If a spacer is needed in the chat, this is used as a spacer:
-	set {SB::config::spacer} to "%{SB::config::color::secondary::2}%&l&m---------------------------------------------"
+  #
+  # > Flags for not inhabited islands:
+  # > Islands like the lobby island or currently not used islands
+  #
+  # > Explosions. True = allowed, false = denied.
+  set {SB::config::defaultlobbyflag::explosion} to false
+  #
+  # > Explosions. True = allowed, false = denied.
+  set {SB::config::defaultlobbyflag::mob-spawning} to false
+  #
+  # > Let players use buttons. True = allowed, false = denied.
+  set {SB::config::defaultlobbyflag::button} to true
+  #
+  # > Let players use the doors. True = allowed, false = denied.
+  set {SB::config::defaultlobbyflag::door} to true
+  #
+  # > Damage on entities like mobs, animals or item frames. True = allowed, false = denied.
+  # > Damage on mobs
+  set {SB::config::defaultlobbyflag::mob-damage} to true
+  #
+  # > Damage on animals
+  set {SB::config::defaultlobbyflag::animal-damage} to false
+  #
+  # > Damage on item frames
+  set {SB::config::defaultlobbyflag::itemframe-damage} to false
 
-	#
-	# > If a spacer is needed in the item gui, this is used as a spacer:
-	set {SB::config::guispacer} to "%{SB::config::color::background::1}%&l&m-----------"
+  #
+  # > Interact with vehicles. True = allowed, false = denied.
+  set {SB::config::defaultlobbyflag::interact-vehicle} to false
+  #
+  # > Allow others to change redstone tools like redstone repeaters. True = allowed, false = denied.
+  set {SB::config::defaultlobbyflag::redstone} to false
 
-	#
-	# > Schematics/Structure Files:
-	# > Add the name of the file here, it should be in the islands folder of this skript, structures have to be 32x32x32 big:
-	set {_schematicname} to "default"
-	add {_schematicname} to {SB::schematics::schematic::*}
-	#
-	# > Add the name that should be visible to the player, add a name for every language:
-	add "&rStandard" to {SB::schematics::name::de::*}
-	#
-	# > Add the lore and also for every language you want to have:
-	add "Die Standard Insel" to {SB::schematics::lore::de::*}
-	#
-	# > Set a price, if the Island should cost something, if it should be free, set it to 0:
-	add "0" to {SB::schematics::price::*}
-	#
-	# > Set chest content for this schematic and also the relative location for the chest
-	set {SB::schematics::loc::%{_schematicname}%::chest} to "0,6,2"
-	#
-	# > Set the teleport location for this shematic in relation:
-	set {SB::schematics::loc::%{_schematicname}%::home} to "-1,5,-1"
+  #
+  # > Color Scheme
+  # > Change this to match the colors with your corporate identity
+  #
+  set {SB::config::color::primary::1} to "&6"
+  set {SB::config::color::primary::2} to "&e"
+  set {SB::config::color::secondary::2} to "&7"
+  set {SB::config::color::background::1} to "&8"
 
-	#
-	# > Set the chest for this island:
-	add "5,grass" to {SB::schematics::chest::%{_schematicname}%::*}
-	add "20,stone" to {SB::schematics::chest::%{_schematicname}%::*}
-	add "1,lava bucket" to {SB::schematics::chest::%{_schematicname}%::*}
-	add "2,ice block" to {SB::schematics::chest::%{_schematicname}%::*}
-	add "50,bone meal" to {SB::schematics::chest::%{_schematicname}%::*}
+  #
+  # > If a spacer is needed in the chat, this is used as a spacer:
+  set {SB::config::spacer} to "%{SB::config::color::secondary::2}%&l&m---------------------------------------------"
 
-	#
-	# > Island upgrade prices (economy plugin required):
-	
-	#
-	# > Island size upgrades:
-	# > Island size 1:
-	set {SB::config::sizeupgrade1} to 10000
-	# > Island size 2:
-	set {SB::config::sizeupgrade2} to 25000
-	# > Island size 3:
-	set {SB::config::sizeupgrade3} to 35000
-	# > Island size 4:
-	set {SB::config::sizeupgrade4} to 45000
-	# > Island size 5:
-	set {SB::config::sizeupgrade5} to 55000
-	
-	#
-	# > Island home upgrades:
-	# > Island home 1:
-	set {SB::config::homeupgrade1} to 1000
-	# > Island home 2:
-	set {SB::config::homeupgrade2} to 2000
-	# > Island home 3:
-	set {SB::config::homeupgrade3} to 3000
-	# > Island home 4:
-	set {SB::config::homeupgrade4} to 4000
-	# > Island home 5:
-	set {SB::config::homeupgrade5} to 5000
-	
-	#
-	# > Island hopper upgrades:
-	# > Island hopper 1:
-	set {SB::config::hopperupgrade1} to 4000
-	# > Island hopper 2:
-	set {SB::config::hopperupgrade2} to 6000
-	# > Island hopper 3:
-	set {SB::config::hopperupgrade3} to 12000
-	# > Island hopper 4:
-	set {SB::config::hopperupgrade4} to 14000
-	# > Island hopper 5:
-	set {SB::config::hopperupgrade5} to 20000
+  #
+  # > If a spacer is needed in the item gui, this is used as a spacer:
+  set {SB::config::guispacer} to "%{SB::config::color::background::1}%&l&m-----------"
 
-	#EXP for each level, if a player has level 5, he needs 500 exp for level 6 level * explevel:
-	set {SB::config::explevel} to 100
+  #
+  # > Schematics/Structure Files:
+  # > Add the name of the file here, it should be in the islands folder of this skript, structures have to be 32x32x32 big:
+  set {_schematicname} to "default"
+  add {_schematicname} to {SB::schematics::schematic::*}
+  #
+  # > Add the name that should be visible to the player, add a name for every language:
+  add "&rStandard" to {SB::schematics::name::de::*}
+  #
+  # > Add the lore and also for every language you want to have:
+  add "Die Standard Insel" to {SB::schematics::lore::de::*}
+  #
+  # > Set a price, if the Island should cost something, if it should be free, set it to 0:
+  add "0" to {SB::schematics::price::*}
+  #
+  # > Set chest content for this schematic and also the relative location for the chest
+  set {SB::schematics::loc::%{_schematicname}%::chest} to "0,6,2"
+  #
+  # > Set the teleport location for this shematic in relation:
+  set {SB::schematics::loc::%{_schematicname}%::home} to "-1,5,-1"
 
-	#EXP Blocks - Set how much experience a block should give for the level calculation:
-	#Only blocks, which are here, are going to give experience.
-	set {SB::expblocks::dirt_block} to 20
-	set {SB::expblocks::grass} to 20
-	set {SB::expblocks::sand} to 15
-	set {SB::expblocks::soil} to 5
-	set {SB::expblocks::cobble_block} to 1
-	set {SB::expblocks::stone_block} to 1.5
-	set {SB::expblocks::slab} to 1
-	set {SB::expblocks::fence} to 2
-	set {SB::expblocks::dry_wall_sign} to 5
-	set {SB::expblocks::floor_torch} to 2
-	set {SB::expblocks::wall_torch} to 2
-	set {SB::expblocks::crafting_table} to 2
-	set {SB::expblocks::wheat_item} to 2
-	set {SB::expblocks::chest} to 2
-	set {SB::expblocks::door} to 2
-	set {SB::expblocks::plant} to 2
-	set {SB::expblocks::sapling} to 2
-	set {SB::expblocks::stem} to 2
-	set {SB::expblocks::stationary_water} to 0
-	set {SB::expblocks::stationary_lava} to 0
-	set {SB::expblocks::log} to 3
-	set {SB::expblocks::furnace} to 8
-	set {SB::expblocks::bedrock} to 0
-	set {SB::expblocks::wool} to 2
-	set {SB::expblocks::pumpkin} to 1
+  #
+  # > Set the chest for this island:
+  add "5,grass" to {SB::schematics::chest::%{_schematicname}%::*}
+  add "20,stone" to {SB::schematics::chest::%{_schematicname}%::*}
+  add "1,lava bucket" to {SB::schematics::chest::%{_schematicname}%::*}
+  add "2,ice block" to {SB::schematics::chest::%{_schematicname}%::*}
+  add "50,bone meal" to {SB::schematics::chest::%{_schematicname}%::*}
 
-	#Blocks:
-	set {SB::expblocks::iron_block} to 20
-	set {SB::expblocks::block_of_diamond} to 150
-	set {SB::expblocks::block_of_redstone} to 30
-	set {SB::expblocks::block_of_lapis_lazuli} to 50
-	set {SB::expblocks::emerald_block} to 75
-	set {SB::expblocks::gold_block} to 50
-	set {SB::expblocks::chiseled_quartz} to 25
-	set {SB::expblocks::quartz_pillar} to 25
-	set {SB::expblocks::nether_quartz_slab} to 10
-	
-	#Other Blocks
-	set {SB::expblocks::stone_brick} to 1.5
-	#Special Blocks:
-	set {SB::expblocks::enchantment_table} to 250
-	set {SB::expblocks::beacon} to 1000
-	set {SB::expblocks::note_block} to 20
-	set {SB::expblocks::jukeboxes} to 15
-	set {SB::expblocks::anvil} to 60
-	set {SB::expblocks::piston} to 4
-	set {SB::expblocks::hopper} to 4
-	set {SB::expblocks::glowstone_block} to 4
-	set {SB::expblocks::flower_pot} to 20
-	set {SB::expblocks::standing_banner} to 10
-	set {SB::expblocks::carpet} to 1.5
-	set {SB::expblocks::bed} to 3
-	set {SB::expblocks::redstone_wire} to 1
+  #
+  # > Island upgrade prices (economy plugin required):
+  
+  #
+  # > Island size upgrades:
+  # > Island size 1:
+  set {SB::config::sizeupgrade1} to 10000
+  # > Island size 2:
+  set {SB::config::sizeupgrade2} to 25000
+  # > Island size 3:
+  set {SB::config::sizeupgrade3} to 35000
+  # > Island size 4:
+  set {SB::config::sizeupgrade4} to 45000
+  # > Island size 5:
+  set {SB::config::sizeupgrade5} to 55000
+  
+  #
+  # > Island home upgrades:
+  # > Island home 1:
+  set {SB::config::homeupgrade1} to 1000
+  # > Island home 2:
+  set {SB::config::homeupgrade2} to 2000
+  # > Island home 3:
+  set {SB::config::homeupgrade3} to 3000
+  # > Island home 4:
+  set {SB::config::homeupgrade4} to 4000
+  # > Island home 5:
+  set {SB::config::homeupgrade5} to 5000
+  
+  #
+  # > Island hopper upgrades:
+  # > Island hopper 1:
+  set {SB::config::hopperupgrade1} to 4000
+  # > Island hopper 2:
+  set {SB::config::hopperupgrade2} to 6000
+  # > Island hopper 3:
+  set {SB::config::hopperupgrade3} to 12000
+  # > Island hopper 4:
+  set {SB::config::hopperupgrade4} to 14000
+  # > Island hopper 5:
+  set {SB::config::hopperupgrade5} to 20000
 
-	#Glass:
-	set {SB::expblocks::glass_block} to 20
-	set {SB::expblocks::glass_pane} to 7
-	#terracotta
-	set {SB::expblocks::glazed_terracotta} to 20
-	#Sandstone:
-	set {SB::expblocks::sandstone_block} to 15
-	#Water blocks:
-	set {SB::expblocks::living_coral_block} to 15
+  #EXP for each level, if a player has level 5, he needs 500 exp for level 6 level * explevel:
+  set {SB::config::explevel} to 100
+
+  #EXP Blocks - Set how much experience a block should give for the level calculation:
+  #Only blocks, which are here, are going to give experience.
+  set {SB::expblocks::dirt_block} to 20
+  set {SB::expblocks::grass} to 20
+  set {SB::expblocks::sand} to 15
+  set {SB::expblocks::soil} to 5
+  set {SB::expblocks::cobble_block} to 1
+  set {SB::expblocks::stone_block} to 1.5
+  set {SB::expblocks::slab} to 1
+  set {SB::expblocks::fence} to 2
+  set {SB::expblocks::dry_wall_sign} to 5
+  set {SB::expblocks::floor_torch} to 2
+  set {SB::expblocks::wall_torch} to 2
+  set {SB::expblocks::crafting_table} to 2
+  set {SB::expblocks::wheat_item} to 2
+  set {SB::expblocks::chest} to 2
+  set {SB::expblocks::door} to 2
+  set {SB::expblocks::plant} to 2
+  set {SB::expblocks::sapling} to 2
+  set {SB::expblocks::stem} to 2
+  set {SB::expblocks::stationary_water} to 0
+  set {SB::expblocks::stationary_lava} to 0
+  set {SB::expblocks::log} to 3
+  set {SB::expblocks::furnace} to 8
+  set {SB::expblocks::bedrock} to 0
+  set {SB::expblocks::wool} to 2
+  set {SB::expblocks::pumpkin} to 1
+
+  #Blocks:
+  set {SB::expblocks::iron_block} to 20
+  set {SB::expblocks::block_of_diamond} to 150
+  set {SB::expblocks::block_of_redstone} to 30
+  set {SB::expblocks::block_of_lapis_lazuli} to 50
+  set {SB::expblocks::emerald_block} to 75
+  set {SB::expblocks::gold_block} to 50
+  set {SB::expblocks::chiseled_quartz} to 25
+  set {SB::expblocks::quartz_pillar} to 25
+  set {SB::expblocks::nether_quartz_slab} to 10
+  
+  #Other Blocks
+  set {SB::expblocks::stone_brick} to 1.5
+  #Special Blocks:
+  set {SB::expblocks::enchantment_table} to 250
+  set {SB::expblocks::beacon} to 1000
+  set {SB::expblocks::note_block} to 20
+  set {SB::expblocks::jukeboxes} to 15
+  set {SB::expblocks::anvil} to 60
+  set {SB::expblocks::piston} to 4
+  set {SB::expblocks::hopper} to 4
+  set {SB::expblocks::glowstone_block} to 4
+  set {SB::expblocks::flower_pot} to 20
+  set {SB::expblocks::standing_banner} to 10
+  set {SB::expblocks::carpet} to 1.5
+  set {SB::expblocks::bed} to 3
+  set {SB::expblocks::redstone_wire} to 1
+
+  #Glass:
+  set {SB::expblocks::glass_block} to 20
+  set {SB::expblocks::glass_pane} to 7
+  #terracotta
+  set {SB::expblocks::glazed_terracotta} to 20
+  #Sandstone:
+  set {SB::expblocks::sandstone_block} to 15
+  #Water blocks:
+  set {SB::expblocks::living_coral_block} to 15
 
 #
 # ADDON Configurations
 #
 
 #Ore Generator:
-	#Use this like this example:
-	#The Chance amount can be between 100% and 0.01%, begin with low percentages
-	#and go forward to bigger changes at the bottom. Do not add the % symbol.
-	#To disable this feature, add a hyphen to the oregenerator.sk in the addons folder.
-	#Example for a chance of 0.2% for diamond ores:
-	#add 0.2 to {SB::oregenc::*}
-	#add diamond ore to {SB::oregen::*}
+  #Use this like this example:
+  #The Chance amount can be between 100% and 0.01%, begin with low percentages
+  #and go forward to bigger changes at the bottom. Do not add the % symbol.
+  #To disable this feature, add a hyphen to the oregenerator.sk in the addons folder.
+  #Example for a chance of 0.2% for diamond ores:
+  #add 0.2 to {SB::oregenc::*}
+  #add diamond ore to {SB::oregen::*}
 
-	add 0.2 to {SB::oregenc::*}
-	add diamond ore to {SB::oregen::*}
-	add 0.3 to {SB::oregenc::*}
-	add nether quartz ore to {SB::oregen::*}
-	add 0.4 to {SB::oregenc::*}
-	add redstone ore to {SB::oregen::*}
-	add 0.5 to {SB::oregenc::*}
-	add lapis ore to {SB::oregen::*}
-	add 1 to {SB::oregenc::*}
-	add gold ore to {SB::oregen::*}
-	add 1.5 to {SB::oregenc::*}
-	add emerald ore to {SB::oregen::*}
-	add 1.5 to {SB::oregenc::*}
-	add iron ore to {SB::oregen::*}
-	add 2 to {SB::oregenc::*}
-	add coal ore to {SB::oregen::*}
-	add 5 to {SB::oregenc::*}
-	add granite to {SB::oregen::*}
-	add 5 to {SB::oregenc::*}
-	add andesite to {SB::oregen::*}
-	add 5 to {SB::oregenc::*}
-	add diorite to {SB::oregen::*}
-	add 100 to {SB::oregenc::*}
-	add stone to {SB::oregen::*}
+  add 0.2 to {SB::oregenc::*}
+  add diamond ore to {SB::oregen::*}
+  add 0.4 to {SB::oregenc::*}
+  add glowstone to {SB::oregen::*}
+  add 0.3 to {SB::oregenc::*}
+  add nether quartz ore to {SB::oregen::*}
+  add 0.4 to {SB::oregenc::*}
+  add redstone ore to {SB::oregen::*}
+  add 0.5 to {SB::oregenc::*}
+  add lapis ore to {SB::oregen::*}
+  add 1 to {SB::oregenc::*}
+  add gold ore to {SB::oregen::*}
+  add 1.5 to {SB::oregenc::*}
+  add emerald ore to {SB::oregen::*}
+  add 1.5 to {SB::oregenc::*}
+  add iron ore to {SB::oregen::*}
+  add 2 to {SB::oregenc::*}
+  add coal ore to {SB::oregen::*}
+  add 5 to {SB::oregenc::*}
+  add granite to {SB::oregen::*}
+  add 5 to {SB::oregenc::*}
+  add andesite to {SB::oregen::*}
+  add 5 to {SB::oregenc::*}
+  add diorite to {SB::oregen::*}
+  add 100 to {SB::oregenc::*}
+  add stone to {SB::oregen::*}
 
-	#
-	# > Mutli level ore generator - Set to false to disable
-	#
-	set {SB::config::oregeneratorleveling} to true
-	
-	#
-	# > Increase ore spawning chances by percentage for every level
-	# > Example: 2 increases the chance of 0.2% to 0,204%
-	#
-	set {SB::config::oregenlevelbonus} to 2
+  #
+  # > Mutli level ore generator - Set to false to disable
+  #
+  set {SB::config::oregeneratorleveling} to true
+  
+  #
+  # > Increase ore spawning chances by percentage for every level
+  # > Example: 2 increases the chance of 0.2% to 0,204%
+  #
+  set {SB::config::oregenlevelbonus} to 2
 
-	#
-	# > How many stone blocks have to be produced until a new level is hit
-	#
-	set {SB::config::oregennewlevel} to 1000
-	
-	#
-	# > Increase the difficulty to get the next ore generator level by multiplying it:
-	#
-	set {SB::config::oregenlevelmultiplyer} to 5
-	
-	#
-	# > Set the max. level bonus in percentage
-	# > 20 is a max. bonus of 20% on the chances
-	#
-	set {SB::config::oregenmaxlevelbonus} to 100
+  #
+  # > How many stone blocks have to be produced until a new level is hit
+  #
+  set {SB::config::oregennewlevel} to 1000
+  
+  #
+  # > Increase the difficulty to get the next ore generator level by multiplying it:
+  #
+  set {SB::config::oregenlevelmultiplyer} to 5
+  
+  #
+  # > Set the max. level bonus in percentage
+  # > 20 is a max. bonus of 20% on the chances
+  #
+  set {SB::config::oregenmaxlevelbonus} to 100
 
 # > Biome changer configuration
 
-	#
-	# > Add all biomes which should be available to change, also add prices.
-	# > Set price to 0 to make it free. Players have to pay every time they
-	# > change the biome to prevent spam.
-	# > Example:
-	# > Adds menu item grass for 50 money to the menu which changes the biome to plains,
-	# > add additional language for every language you have.
-	#add "grass" to {SB::config::biome::menuitem::*}
-	#add "plains" to {SB::config::biome::biomename::*}
-	#add 50 to {SB::config::biome::price::*}
-	#add "Flachland" to {SB::config::biome::lang::de::*}
-	
-	add "barrier" to {SB::config::biome::menuitem::*}
-	add "the void" to {SB::config::biome::biomename::*}
-	add 500 to {SB::config::biome::price::*}
-	add "Die Leere" to {SB::config::biome::lang::de::*}
-	
-	add "grass" to {SB::config::biome::menuitem::*}
-	add "plains" to {SB::config::biome::biomename::*}
-	add 500 to {SB::config::biome::price::*}
-	add "Flachland" to {SB::config::biome::lang::de::*}
+  #
+  # > Add all biomes which should be available to change, also add prices.
+  # > Set price to 0 to make it free. Players have to pay every time they
+  # > change the biome to prevent spam.
+  # > Example:
+  # > Adds menu item grass for 50 money to the menu which changes the biome to plains,
+  # > add additional language for every language you have.
+  #add "grass" to {SB::config::biome::menuitem::*}
+  #add "plains" to {SB::config::biome::biomename::*}
+  #add 50 to {SB::config::biome::price::*}
+  #add "Flachland" to {SB::config::biome::lang::de::*}
+  
+  add "barrier" to {SB::config::biome::menuitem::*}
+  add "the void" to {SB::config::biome::biomename::*}
+  add 500 to {SB::config::biome::price::*}
+  add "Die Leere" to {SB::config::biome::lang::de::*}
+  
+  add "grass" to {SB::config::biome::menuitem::*}
+  add "plains" to {SB::config::biome::biomename::*}
+  add 500 to {SB::config::biome::price::*}
+  add "Flachland" to {SB::config::biome::lang::de::*}
 
-	add "sand" to {SB::config::biome::menuitem::*}
-	add "desert" to {SB::config::biome::biomename::*}
-	add 500 to {SB::config::biome::price::*}
-	add "Wüste" to {SB::config::biome::lang::de::*}
+  add "sand" to {SB::config::biome::menuitem::*}
+  add "desert" to {SB::config::biome::biomename::*}
+  add 500 to {SB::config::biome::price::*}
+  add "Wüste" to {SB::config::biome::lang::de::*}
 
-	add "snow block" to {SB::config::biome::menuitem::*}
-	add "ICE_PLAINS" to {SB::config::biome::biomename::*}
-	add 500 to {SB::config::biome::price::*}
-	add "Schnee" to {SB::config::biome::lang::de::*}
+  add "snow block" to {SB::config::biome::menuitem::*}
+  add "ICE_PLAINS" to {SB::config::biome::biomename::*}
+  add 500 to {SB::config::biome::price::*}
+  add "Schnee" to {SB::config::biome::lang::de::*}
 
-	add "jungle leaves" to {SB::config::biome::menuitem::*}
-	add "jungle" to {SB::config::biome::biomename::*}
-	add 500 to {SB::config::biome::price::*}
-	add "Dschungel" to {SB::config::biome::lang::de::*}
+  add "jungle leaves" to {SB::config::biome::menuitem::*}
+  add "jungle" to {SB::config::biome::biomename::*}
+  add 500 to {SB::config::biome::price::*}
+  add "Dschungel" to {SB::config::biome::lang::de::*}
 
-	add "light blue concrete powder" to {SB::config::biome::menuitem::*}
-	add "warm ocean" to {SB::config::biome::biomename::*}
-	add 500 to {SB::config::biome::price::*}
-	add "Warmer Ozean" to {SB::config::biome::lang::de::*}
+  add "light blue concrete powder" to {SB::config::biome::menuitem::*}
+  add "warm ocean" to {SB::config::biome::biomename::*}
+  add 500 to {SB::config::biome::price::*}
+  add "Warmer Ozean" to {SB::config::biome::lang::de::*}
 
 #
 # > Functions to start after config loaded, do not change this if you don't know what you're doing.
-	loadislandstoworld()
+#
+  loadislandstoworld()

--- a/SkyBlock/lang/de.sk
+++ b/SkyBlock/lang/de.sk
@@ -3,292 +3,294 @@
 # > COMPATIBLE VERSION: x (there is no release yet)
 #
 on script load:
-	set {_lang} to "de"
-	
-	set {SB::lang::language::%{_lang}%} to "Deutsch"
-	set {SB::lang::languageskin::%{_lang}%} to "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNWU3ODk5YjQ4MDY4NTg2OTdlMjgzZjA4NGQ5MTczZmU0ODc4ODY0NTM3NzQ2MjZiMjRiZDhjZmVjYzc3YjNmIn19fQ=="
+  set {_lang} to "de"
+  
+  set {SB::lang::language::%{_lang}%} to "Deutsch"
+  set {SB::lang::languageskin::%{_lang}%} to "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNWU3ODk5YjQ4MDY4NTg2OTdlMjgzZjA4NGQ5MTczZmU0ODc4ODY0NTM3NzQ2MjZiMjRiZDhjZmVjYzc3YjNmIn19fQ=="
 
-	#
-	# > Local variables for color schemes:
-	#
-	set {_p1} to {SB::config::color::primary::1}
-	set {_p2} to {SB::config::color::primary::2}
-	set {_s1} to {SB::config::color::secondary::2}
-	set {_b1} to {SB::config::color::background::1}
+  #
+  # > Local variables for color schemes:
+  #
+  set {_p1} to {SB::config::color::primary::1}
+  set {_p2} to {SB::config::color::primary::2}
+  set {_s1} to {SB::config::color::secondary::2}
+  set {_b1} to {SB::config::color::background::1}
 
-	#
-	# > Command feedback messages
-	#
+  #
+  # > Command feedback messages
+  #
 
-	#
-	# > /island create
-	#
-	set {SB::lang::searchis::%{_lang}%} to "%{_p2}%Freie Inseln werden gesucht."
-	set {SB::lang::foundis::%{_lang}%} to "%{_p1}%Deine neue Insel wurde erstellt."
-	set {SB::lang::islands::%{_lang}%} to "%{_s1}%&lInseln"
-	
-	#
-	# > /island home | /island go
-	#
-	set {SB::lang::tpis::%{_lang}%} to "%{_p1}%Du wurdest zur Insel teleportiert."
-	set {SB::lang::tphome::%{_lang}%} to "%{_p1}%Du wurdest zum Zuhause teleportiert."
-	set {SB::lang::homewarnair::%{_lang}%} to "&cWarnung, dein Zuhause ist in der Luft!"
-	set {SB::lang::deledtedis::%{_lang}%} to "&c&lDeine Insel wurde gelöscht."
-	set {SB::lang::alreadyis::%{_lang}%} to "%{_s1}%Du bist bereits auf einer Insel."
-	set {SB::lang::alreadyotheris::%{_lang}%} to "%{_s1}%<player> ist bereits auf einer Insel."
-	set {SB::lang::waitis::%{_lang}%} to "%{_p2}%&lEinen Moment..."
-	set {SB::lang::cantleave::%{_lang}%} to "%{_s1}%Du kannst diese Insel nicht verlassen."
-	set {SB::lang::notfoundhome::%{_lang}%} to "%{_s1}%Deine Zuhause: <homes>"
-	
-	#
-	# > /island invite | /island join
-	#
-	set {SB::lang::sentrequest::%{_lang}%} to "%{_p2}%Du hat eine Anfrage geschickt."
-	set {SB::lang::gotrequest::%{_lang}%} to "%{_p2}%Du hast eine Inseleinladung von <player> erhalten."
-	set {SB::lang::reqtoleader::%{_lang}%} to "%{_s1}%Die Einladung wurde &nnicht%{_s1}% angenommen."
-	set {SB::lang::clicktojoin::%{_lang}%} to "Klicke Hier, um <player> beizutreten."
-	set {SB::lang::reqtomember::%{_lang}%} to "%{_s1}%Die Einladung ist &labgelaufen%{_s1}%."
-	set {SB::lang::cantinviteself::%{_lang}%} to "&cDu kannst dich nicht selber einladen."
-	set {SB::lang::joinedismember::%{_lang}%} to "%{_p2}%Du bist der Insel von <arg-2> beigetreten."
-	set {SB::lang::joinedisleader::%{_lang}%} to "%{_p2}%<player> ist der Insel beigetreten."
-	set {SB::lang::norequest::%{_lang}%} to "%{_s1}%Keine Einladungen verfügbar."
-	set {SB::lang::requests::%{_lang}%} to "%{_s1}%Einladungen:"
-	set {SB::lang::invitetargeterror::%{_lang}%} to "%{_s1}%Es konnte keine Einladung an <arg-2> gesendet werden."
-	
-	#
-	# > /island leave
-	#
-	set {SB::lang::leftis::%{_lang}%} to "%{_s1}%Du hast die Insel verlassen."
+  #
+  # > /island create
+  #
+  set {SB::lang::searchis::%{_lang}%} to "%{_p2}%Freie Inseln werden gesucht."
+  set {SB::lang::foundis::%{_lang}%} to "%{_p1}%Deine neue Insel wurde erstellt."
+  set {SB::lang::islands::%{_lang}%} to "%{_s1}%&lInseln"
+  
+  #
+  # > /island home | /island go
+  #
+  set {SB::lang::tpis::%{_lang}%} to "%{_p1}%Du wurdest zur Insel teleportiert."
+  set {SB::lang::tphome::%{_lang}%} to "%{_p1}%Du wurdest zum Zuhause teleportiert."
+  set {SB::lang::homewarnair::%{_lang}%} to "&cWarnung, dein Zuhause ist in der Luft!"
+  set {SB::lang::deledtedis::%{_lang}%} to "&c&lDeine Insel wurde gelöscht."
+  set {SB::lang::alreadyis::%{_lang}%} to "%{_s1}%Du bist bereits auf einer Insel."
+  set {SB::lang::alreadyotheris::%{_lang}%} to "%{_s1}%<player> ist bereits auf einer Insel."
+  set {SB::lang::waitis::%{_lang}%} to "%{_p2}%&lEinen Moment..."
+  set {SB::lang::cantleave::%{_lang}%} to "%{_s1}%Du kannst diese Insel nicht verlassen."
+  set {SB::lang::notfoundhome::%{_lang}%} to "%{_s1}%Deine Zuhause: <homes>"
+  
+  #
+  # > /island invite | /island join
+  #
+  set {SB::lang::sentrequest::%{_lang}%} to "%{_p2}%Du hat eine Anfrage geschickt."
+  set {SB::lang::gotrequest::%{_lang}%} to "%{_p2}%Du hast eine Inseleinladung von <player> erhalten."
+  set {SB::lang::reqtoleader::%{_lang}%} to "%{_s1}%Die Einladung wurde &nnicht%{_s1}% angenommen."
+  set {SB::lang::clicktojoin::%{_lang}%} to "Klicke Hier, um <player> beizutreten."
+  set {SB::lang::reqtomember::%{_lang}%} to "%{_s1}%Die Einladung ist &labgelaufen%{_s1}%."
+  set {SB::lang::cantinviteself::%{_lang}%} to "&cDu kannst dich nicht selber einladen."
+  set {SB::lang::joinedismember::%{_lang}%} to "%{_p2}%Du bist der Insel von <arg-2> beigetreten."
+  set {SB::lang::joinedisleader::%{_lang}%} to "%{_p2}%<player> ist der Insel beigetreten."
+  set {SB::lang::norequest::%{_lang}%} to "%{_s1}%Keine Einladungen verfügbar."
+  set {SB::lang::requests::%{_lang}%} to "%{_s1}%Einladungen:"
+  set {SB::lang::invitetargeterror::%{_lang}%} to "%{_s1}%Es konnte keine Einladung an <arg-2> gesendet werden."
+  
+  #
+  # > /island leave
+  #
+  set {SB::lang::leftis::%{_lang}%} to "%{_s1}%Du hast die Insel verlassen."
 
-	#
-	# > /island kick
-	#
-	set {SB::lang::kickmemberleader::%{_lang}%} to "%{_s1}%Du hast <arg-2> von der Insel gekickt."
-	set {SB::lang::kickmember::%{_lang}%} to "%{_s1}%Du wurdest von der Insel von <player> gekickt."
-	
-	#
-	# > /island sethome
-	#
-	set {SB::lang::sethomeok::%{_lang}%} to "Zuhause erfolgreich erstellt."
-	set {SB::lang::ishomecancel::%{_lang}%} to "Das neue Zuhause muss auf deiner Insel sein."
-	set {SB::lang::sethomeoverwritten::%{_lang}%} to "Zuhause erfolgreich überschrieben."
-	set {SB::lang::homedeleted::%{_lang}%} to "Zuhause <home> wurde entfernt."
-	set {SB::lang::cantdeletehome::%{_lang}%} to "<home> kann nicht entfernt werden."
-	set {SB::lang::sethomelmitreached::%{_lang}%} to "Du hast das Limit für noch mehr Zuhase erreicht."
+  #
+  # > /island kick
+  #
+  set {SB::lang::kickmemberleader::%{_lang}%} to "%{_s1}%Du hast <arg-2> von der Insel gekickt."
+  set {SB::lang::kickmember::%{_lang}%} to "%{_s1}%Du wurdest von der Insel von <player> gekickt."
+  
+  #
+  # > /island sethome
+  #
+  set {SB::lang::sethomeok::%{_lang}%} to "Zuhause erfolgreich erstellt."
+  set {SB::lang::ishomecancel::%{_lang}%} to "Das neue Zuhause muss auf deiner Insel sein."
+  set {SB::lang::sethomeoverwritten::%{_lang}%} to "Zuhause erfolgreich überschrieben."
+  set {SB::lang::homedeleted::%{_lang}%} to "Zuhause <home> wurde entfernt."
+  set {SB::lang::cantdeletehome::%{_lang}%} to "<home> kann nicht entfernt werden."
+  set {SB::lang::sethomelmitreached::%{_lang}%} to "Du hast das Limit für noch mehr Zuhase erreicht."
 
-	#
-	# > /island warp|setwarp|delwarp
-	#
-	set {SB::lang::setwarpok::%{_lang}%} to "Der Warp wurde erfolgreich erstellt."
-	set {SB::lang::delwarpok::%{_lang}%} to "Der Warp wurde erfolgreich gelöscht."
-	set {SB::lang::warpnotfound::%{_lang}%} to "Dieser Warp wurde nicht gefunden."
+  #
+  # > /island warp|setwarp|delwarp
+  #
+  set {SB::lang::setwarpok::%{_lang}%} to "Der Warp wurde erfolgreich erstellt."
+  set {SB::lang::delwarpok::%{_lang}%} to "Der Warp wurde erfolgreich gelöscht."
+  set {SB::lang::warpnotfound::%{_lang}%} to "Dieser Warp wurde nicht gefunden."
 
-	#
-	# > /island info:
-	#
-	set {SB::lang::isinfo::%{_lang}%} to "Informationen über diese Insel:"
-	set {SB::lang::isleader::%{_lang}%} to "Inselleiter:"
-	set {SB::lang::ismember::%{_lang}%} to "Mitglieder:"
-	set {SB::lang::istrusted::%{_lang}%} to "Vertraute:"
-	set {SB::lang::isinfolevel::%{_lang}%} to "Level:"
-	set {SB::lang::iscreated::%{_lang}%} to "Erstellt:"
-	set {SB::lang::islastactive::%{_lang}%} to "Zuletzt aktiv:"
-	set {SB::lang::isupgrades::%{_lang}%} to "Inselverbesserungen:"
-	set {SB::lang::isinfonotfound::%{_lang}%} to "Insel konnte nicht gefunden werden."
+  #
+  # > /island info:
+  #
+  set {SB::lang::isinfo::%{_lang}%} to "Informationen über diese Insel:"
+  set {SB::lang::isleader::%{_lang}%} to "Inselleiter:"
+  set {SB::lang::ismember::%{_lang}%} to "Mitglieder:"
+  set {SB::lang::istrusted::%{_lang}%} to "Vertraute:"
+  set {SB::lang::isinfolevel::%{_lang}%} to "Level:"
+  set {SB::lang::iscreated::%{_lang}%} to "Erstellt:"
+  set {SB::lang::islastactive::%{_lang}%} to "Zuletzt aktiv:"
+  set {SB::lang::isupgrades::%{_lang}%} to "Inselverbesserungen:"
+  set {SB::lang::isinfonotfound::%{_lang}%} to "Insel konnte nicht gefunden werden."
 
-	#
-	# > /island trust:
-	#
-	set {SB::lang::trustplayerlist::%{_lang}%} to "Alle vertrauten Spieler:"
-	set {SB::lang::alreadytrusted::%{_lang}%} to "Diesem Spieler wird schon vertraut."
-	set {SB::lang::trustnowtrusted::%{_lang}%} to "<player> wird nun vertraut."
-	set {SB::lang::notfoundplayer::%{_lang}%} to "Der Spieler wurde nicht gefunden."
-	set {SB::lang::trustremoved::%{_lang}%} to "<player> wird nicht länger vertraut."
+  #
+  # > /island trust:
+  #
+  set {SB::lang::trustplayerlist::%{_lang}%} to "Alle vertrauten Spieler:"
+  set {SB::lang::alreadytrusted::%{_lang}%} to "Diesem Spieler wird schon vertraut."
+  set {SB::lang::trustnowtrusted::%{_lang}%} to "<player> wird nun vertraut."
+  set {SB::lang::notfoundplayer::%{_lang}%} to "Der Spieler wurde nicht gefunden."
+  set {SB::lang::trustremoved::%{_lang}%} to "<player> wird nicht länger vertraut."
 
-	#
-	# > /island help
-	#
-	set {SB::lang::iscreate::%{_lang}%} to "%{_p2}%&lInsel erstellen %{_s1}%- %{_p1}%/is create"
-	set {SB::lang::isdelete::%{_lang}%} to "%{_p2}%&lInsel löschen %{_s1}%- %{_p1}%/is delete"
-	set {SB::lang::isteleport::%{_lang}%} to "%{_p2}%&lZur Insel teleportieren %{_s1}%- %{_p1}%/is home"
-	set {SB::lang::issethome::%{_lang}%} to "%{_p2}%&lInsel Zuhause ändern %{_s1}%- %{_p1}%/is sethome"
-	set {SB::lang::isteleportgo::%{_lang}%} to "%{_p2}%&lZum Grundstein teleportieren %{_s1}%- %{_p1}%/is go"
-	set {SB::lang::islevel::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lInsel Level %{_s1}%- %{_p1}%/is level"
-	set {SB::lang::istop::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lTop 10 %{_s1}%- %{_p1}%/is top <Seite>"
-	set {SB::lang::isinvite::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lSpieler einladen %{_s1}%- %{_p1}%/is invite <Spieler>"
-	set {SB::lang::iskick::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lSpieler rauswerfen %{_s1}%- %{_p1}%/is kick <Spieler>"
-	set {SB::lang::isjoin::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lEinladung annehmen %{_s1}%- %{_p1}%/is join <Spieler>"
-	set {SB::lang::isleave::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lInsel verlassen %{_s1}%- %{_p1}%/is leave"
-	set {SB::lang::isgui::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lSkyblock Menü %{_s1}%- %{_p1}%/is"
-	set {SB::lang::isspawn::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lZur Lobby %{_s1}%- %{_p1}%/is spawn"
-	set {SB::lang::isore::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lErz Chancen %{_s1}%- %{_p1}%/is ore"
-	set {SB::lang::isgen::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lGenerator Level %{_s1}%- %{_p1}%/is gen"
-	set {SB::lang::trustadd::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lVertraue einem Spieler %{_s1}%- %{_p1}%/is trust add <player>"
-	set {SB::lang::trustremove::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lTraue dem Spieler nicht länger %{_s1}%- %{_p1}%/is trust remove <player>"
-	set {SB::lang::trustlist::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lListe aller vertrauten Spieler %{_s1}%- %{_p1}%/is trust list"
-	set {SB::lang::flaglist::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lÖffnet das Flag menü %{_s1}%- %{_p1}%/is flags"
-	set {SB::lang::helpwarp::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lTeleportiert zum Warp %{_s1}%- %{_p1}%/is warp <Spieler>"
-	set {SB::lang::helpsetwarp::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lSetzt deinen Inselwarp %{_s1}%- %{_p1}%/is setwarp"
-	set {SB::lang::helpdelwarp::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lLöscht deinen Inselwarp %{_s1}%- %{_p1}%/is delwarp"
-	set {SB::lang::helps2::%{_lang}%} to "Seite"
+  #
+  # > /island help
+  #
+  set {SB::lang::iscreate::%{_lang}%} to "%{_p2}%&lInsel erstellen %{_s1}%- %{_p1}%/is create"
+  set {SB::lang::isdelete::%{_lang}%} to "%{_p2}%&lInsel löschen %{_s1}%- %{_p1}%/is delete"
+  set {SB::lang::isteleport::%{_lang}%} to "%{_p2}%&lZur Insel teleportieren %{_s1}%- %{_p1}%/is home"
+  set {SB::lang::issethome::%{_lang}%} to "%{_p2}%&lInsel Zuhause ändern %{_s1}%- %{_p1}%/is sethome"
+  set {SB::lang::isteleportgo::%{_lang}%} to "%{_p2}%&lZum Grundstein teleportieren %{_s1}%- %{_p1}%/is go"
+  set {SB::lang::islevel::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lInsel Level %{_s1}%- %{_p1}%/is level"
+  set {SB::lang::istop::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lTop 10 %{_s1}%- %{_p1}%/is top <Seite>"
+  set {SB::lang::isinvite::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lSpieler einladen %{_s1}%- %{_p1}%/is invite <Spieler>"
+  set {SB::lang::iskick::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lSpieler rauswerfen %{_s1}%- %{_p1}%/is kick <Spieler>"
+  set {SB::lang::isjoin::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lEinladung annehmen %{_s1}%- %{_p1}%/is join <Spieler>"
+  set {SB::lang::isleave::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lInsel verlassen %{_s1}%- %{_p1}%/is leave"
+  set {SB::lang::isgui::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lSkyblock Menü %{_s1}%- %{_p1}%/is"
+  set {SB::lang::isspawn::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lZur Lobby %{_s1}%- %{_p1}%/is spawn"
+  set {SB::lang::isore::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lErz Chancen %{_s1}%- %{_p1}%/is ore"
+  set {SB::lang::isgen::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lGenerator Level %{_s1}%- %{_p1}%/is gen"
+  set {SB::lang::trustadd::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lVertraue einem Spieler %{_s1}%- %{_p1}%/is trust add <player>"
+  set {SB::lang::trustremove::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lTraue dem Spieler nicht länger %{_s1}%- %{_p1}%/is trust remove <player>"
+  set {SB::lang::trustlist::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lListe aller vertrauten Spieler %{_s1}%- %{_p1}%/is trust list"
+  set {SB::lang::flaglist::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lÖffnet das Flag menü %{_s1}%- %{_p1}%/is flags"
+  set {SB::lang::helpwarp::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lTeleportiert zum Warp %{_s1}%- %{_p1}%/is warp <Spieler>"
+  set {SB::lang::helpsetwarp::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lSetzt deinen Inselwarp %{_s1}%- %{_p1}%/is setwarp"
+  set {SB::lang::helpdelwarp::%{_lang}%} to "%{_p1}%&l> %{_p2}%&lLöscht deinen Inselwarp %{_s1}%- %{_p1}%/is delwarp"
+  set {SB::lang::helps2::%{_lang}%} to "Seite"
 
-	#
-	# > /island - Errors
-	#
-	set {SB::lang::notallowed::%{_lang}%} to "&cDer Befehl ist dem Inselbesitzer vorbehalten."
-	set {SB::lang::notleader::%{_lang}%} to " &cDu bist nicht der Inselbesitzer."
-	set {SB::lang::notleaderofthisisland::%{_lang}%} to " &cDu bist nicht der Inselbesitzer dieser Insel."
-	set {SB::lang::noperm::%{_lang}%} to "&c&lDu besitzt keine Berechtigung für diesen Befehl."
-	set {SB::lang::leaderleaveinfo::%{_lang}%} to "%{_s1}%Verwende /is delete, um deine Insel zu löschen."
-	set {SB::lang::havetodelete::%{_lang}%} to "%{_s1}%Verwende /is delete, um deine Insel zu löschen."
-	set {SB::lang::nois::%{_lang}%} to "&cDu hast keine Insel. Erstelle eine: &4&l/island create"
-	set {SB::lang::playeroff::%{_lang}%} to "%{_s1}%Dieser Spieler ist offline."
-	set {SB::lang::havetoleave::%{_lang}%} to "%{_s1}%Verwende /is leave, um die Insel zu verlassen."
-	set {SB::lang::cooldown::%{_lang}%} to "%{_s1}%Dieser Befehl lädt noch auf."
-	set {SB::lang::plnotfound::%{_lang}%} to "%{_s1}%<player> konnte nicht gefunden werden."
-	set {SB::lang::notanumber::%{_lang}%} to "&cBitte verwende Nummern und keinen Text."
-	set {SB::lang::pagenotfound::%{_lang}%} to "&cDiese Seite exestiert nicht. Es gibt nur <pages> Seiten."
-	set {SB::lang::helpsiteerror::%{_lang}%} to "%{_p1}%/is help <Seite>"
+  #
+  # > /island - Errors
+  #
+  set {SB::lang::notallowed::%{_lang}%} to "&cDer Befehl ist dem Inselbesitzer vorbehalten."
+  set {SB::lang::notleader::%{_lang}%} to " &cDu bist nicht der Inselbesitzer."
+  set {SB::lang::notleaderofthisisland::%{_lang}%} to " &cDu bist nicht der Inselbesitzer dieser Insel."
+  set {SB::lang::noperm::%{_lang}%} to "&c&lDu besitzt keine Berechtigung für diesen Befehl."
+  set {SB::lang::leaderleaveinfo::%{_lang}%} to "%{_s1}%Verwende /is delete, um deine Insel zu löschen."
+  set {SB::lang::havetodelete::%{_lang}%} to "%{_s1}%Verwende /is delete, um deine Insel zu löschen."
+  set {SB::lang::nois::%{_lang}%} to "&cDu hast keine Insel. Erstelle eine: &4&l/island create"
+  set {SB::lang::playeroff::%{_lang}%} to "%{_s1}%Dieser Spieler ist offline."
+  set {SB::lang::havetoleave::%{_lang}%} to "%{_s1}%Verwende /is leave, um die Insel zu verlassen."
+  set {SB::lang::cooldown::%{_lang}%} to "%{_s1}%Dieser Befehl lädt noch auf."
+  set {SB::lang::plnotfound::%{_lang}%} to "%{_s1}%<player> konnte nicht gefunden werden."
+  set {SB::lang::notanumber::%{_lang}%} to "&cBitte verwende Nummern und keinen Text."
+  set {SB::lang::pagenotfound::%{_lang}%} to "&cDiese Seite exestiert nicht. Es gibt nur <pages> Seiten."
+  set {SB::lang::helpsiteerror::%{_lang}%} to "%{_p1}%/is help <Seite>"
 
-	#
-	# > /isadmin - command feedback
-	#
-	set {SB::lang::isadmin::deletedxis::%{_lang}%} to "<amount> Inseln wurden gelöscht."
-	set {SB::lang::isadmin::xwouldbedeleted::%{_lang}%} to "<amount> Insel würden gelöscht werden, möchtest du löschen?"
-	set {SB::lang::isadmin::areyousuretodelete::%{_lang}%} to "Bist du sicher, <amount> Insel zu löschen?"
-	set {SB::lang::isadmin::yes::%{_lang}%} to "&6&lYes."
-	set {SB::lang::isadmin::suretodeleteisofp::%{_lang}%} to "Bist du sicher, dass die Insel von <player> gelöscht werden soll?"
-	set {SB::lang::isadmin::kickall::%{_lang}%} to "Jeder wurde von dieser Insel gekickt."
-	set {SB::lang::isadmin::kickallprompt::%{_lang}%} to "Möchtest du alle von <player> Insel kicken?"
-	set {SB::lang::isadmin::islandofdeleted::%{_lang}%} to "Die Insel von <player> wurde gelöscht."
-	set {SB::lang::isadmin::newleaderhastobemember::%{_lang}%} to "Der neue Inselleiter muss Inselmitglied sein."
-	set {SB::lang::isadmin::newleader::%{_lang}%} to "<newleader> ist nun der neue Leiter, <oldleader> ist nun Mitglied der Insel."
-	set {SB::lang::isadmin::changeleader::%{_lang}%} to "Möchtest du den Inselleiter von <oldleader> zu <newleader> wecchseln?"
-	set {SB::lang::isadmin::fcalc::%{_lang}%} to "Das Insellevel wird nun berechnet."
-	set {SB::lang::isadmin::isremovedonrestart::%{_lang}%} to "Die Inseln werden nach einem neustart gelöscht."
+  #
+  # > /isadmin - command feedback
+  #
+  set {SB::lang::isadmin::deletedxis::%{_lang}%} to "<amount> Inseln wurden gelöscht."
+  set {SB::lang::isadmin::xwouldbedeleted::%{_lang}%} to "<amount> Insel würden gelöscht werden, möchtest du löschen?"
+  set {SB::lang::isadmin::areyousuretodelete::%{_lang}%} to "Bist du sicher, <amount> Insel zu löschen?"
+  set {SB::lang::isadmin::yes::%{_lang}%} to "&6&lYes."
+  set {SB::lang::isadmin::suretodeleteisofp::%{_lang}%} to "Bist du sicher, dass die Insel von <player> gelöscht werden soll?"
+  set {SB::lang::isadmin::kickall::%{_lang}%} to "Jeder wurde von dieser Insel gekickt."
+  set {SB::lang::isadmin::kickallprompt::%{_lang}%} to "Möchtest du alle von <player> Insel kicken?"
+  set {SB::lang::isadmin::islandofdeleted::%{_lang}%} to "Die Insel von <player> wurde gelöscht."
+  set {SB::lang::isadmin::newleaderhastobemember::%{_lang}%} to "Der neue Inselleiter muss Inselmitglied sein."
+  set {SB::lang::isadmin::newleader::%{_lang}%} to "<newleader> ist nun der neue Leiter, <oldleader> ist nun Mitglied der Insel."
+  set {SB::lang::isadmin::changeleader::%{_lang}%} to "Möchtest du den Inselleiter von <oldleader> zu <newleader> wecchseln?"
+  set {SB::lang::isadmin::fcalc::%{_lang}%} to "Das Insellevel wird nun berechnet."
+  set {SB::lang::isadmin::isremovedonrestart::%{_lang}%} to "Die Inseln werden nach einem neustart gelöscht."
 
-	#
-	# > Event cancel messages
-	#
-	set {SB::lang::protect::%{_lang}%} to "Dieses Gebiet ist gesichert."
-	set {SB::lang::clearkick::%{_lang}%} to "Der Server startet neu. Warte einen Moment."
-	set {SB::lang::nopvp::%{_lang}%} to "&cPvP ist hier nicht möglich."
-	
-	#
-	# > GUI - menu - Titles
-	#
-	set {SB::lang::guigrassname::%{_lang}%} to "%{_p1}%&lSkyblock"
-	set {SB::lang::guisoonname::%{_lang}%} to "&4&lDemnächst..."
-	set {SB::lang::guigraslore::%{_lang}%} to "&9&lStarte eine Insel"
-	set {SB::lang::guiexpname::%{_lang}%} to "&9&lInsel Level"
-	set {SB::lang::guichallangename::%{_lang}%} to "&a&lTägliche Aufgaben"
-	set {SB::lang::guitopname::%{_lang}%} to "&c&lTop &n10"
-	set {SB::lang::guirewardsname::%{_lang}%} to "&d&lVoting Belohnungen"
-	set {SB::lang::guihubname::%{_lang}%} to "%{_p1}%&lLobby"
-	
-	#
-	# > Chat headers
-	#
-	set {SB::lang::topheader::%{_lang}%} to "&lTop 10 Inseln"
-	set {SB::lang::levelheader::%{_lang}%} to " %{_p2}%Insel Level %{_s1}%&l- %{_p1}%"
-	set {SB::lang::votereward::%{_lang}%} to "&bVote für Belohnungen: "
-	set {SB::lang::rewardwoods::%{_lang}%} to "%{_p1}%Holzkiste"
-	set {SB::lang::rewardenchant::%{_lang}%} to "&5Effektkiste"
-	set {SB::lang::rewardender::%{_lang}%} to "&3Enderkiste"
-	set {SB::lang::rewardunknown::%{_lang}%} to "&4Unbekannte Kiste"
+  #
+  # > Event cancel messages
+  #
+  set {SB::lang::protect::%{_lang}%} to "Dieses Gebiet ist gesichert."
+  set {SB::lang::clearkick::%{_lang}%} to "Der Server startet neu. Warte einen Moment."
+  set {SB::lang::nopvp::%{_lang}%} to "&cPvP ist hier nicht möglich."
+  
+  #
+  # > GUI - menu - Titles
+  #
+  set {SB::lang::guigrassname::%{_lang}%} to "%{_p1}%&lSkyblock"
+  set {SB::lang::guisoonname::%{_lang}%} to "&4&lDemnächst..."
+  set {SB::lang::guigraslore::%{_lang}%} to "&9&lStarte eine Insel"
+  set {SB::lang::guiexpname::%{_lang}%} to "&9&lInsel Level"
+  set {SB::lang::guichallangename::%{_lang}%} to "&a&lTägliche Aufgaben"
+  set {SB::lang::guitopname::%{_lang}%} to "&c&lTop &n10"
+  set {SB::lang::guirewardsname::%{_lang}%} to "&d&lVoting Belohnungen"
+  set {SB::lang::guihubname::%{_lang}%} to "%{_p1}%&lLobby"
+  
+  #
+  # > Chat headers
+  #
+  set {SB::lang::topheader::%{_lang}%} to "&lTop 10 Inseln"
+  set {SB::lang::levelheader::%{_lang}%} to " %{_p2}%Insel Level %{_s1}%&l- %{_p1}%"
+  set {SB::lang::votereward::%{_lang}%} to "&bVote für Belohnungen: "
+  set {SB::lang::rewardwoods::%{_lang}%} to "%{_p1}%Holzkiste"
+  set {SB::lang::rewardenchant::%{_lang}%} to "&5Effektkiste"
+  set {SB::lang::rewardender::%{_lang}%} to "&3Enderkiste"
+  set {SB::lang::rewardunknown::%{_lang}%} to "&4Unbekannte Kiste"
 
-	#
-	# > Other
-	#
-	set {SB::lang::prefix::%{_lang}%} to "%{_s1}%[%{_p1}%&lSkyBlock%{_s1}%] %{_b1}%&l>>&r"
-	set {SB::lang::delismsg::%{_lang}%} to "%{_p2}%Alte Inseln werden gerade gelöscht, bitte warte kurz."
-	set {SB::lang::deletekickmember::%{_lang}%} to "%{_s1}%Die Insel, auf der du Mitglied warst, wurde gelöscht."
-	set {SB::lang::nonether::%{_lang}%} to "%{_s1}%Die Hölle ist nicht zugänglich."
-	set {SB::lang::isdeleteqestion::%{_lang}%} to "%{_s1}%Du möchtest deine Insel löschen? %{_p1}%Klicke Hier%{_s1}%"
-	
-	#
-	# > Admintools:
-	set {SB::lang::at::isalreadyset::%{_lang}%} to "%{_s1}%There is already a bedrock or a island set. Kick everyone first and remove the bedrock, then create the new island."
-	set {SB::lang::at::isnowset::%{_lang}%} to "%{_s1}%The island is now set, add a island leader with /isadmin island addmember <new leader>."
+  #
+  # > Other
+  #
+  set {SB::lang::prefix::%{_lang}%} to "%{_s1}%[%{_p1}%&lSkyBlock%{_s1}%] %{_b1}%&l>>&r"
+  set {SB::lang::delismsg::%{_lang}%} to "%{_p2}%Alte Inseln werden gerade gelöscht, bitte warte kurz."
+  set {SB::lang::deletekickmember::%{_lang}%} to "%{_s1}%Die Insel, auf der du Mitglied warst, wurde gelöscht."
+  set {SB::lang::nonether::%{_lang}%} to "%{_s1}%Die Hölle ist nicht zugänglich."
+  set {SB::lang::isdeleteqestion::%{_lang}%} to "%{_s1}%Du möchtest deine Insel löschen? %{_p1}%Klicke Hier%{_s1}%"
+  
+  #
+  # > Admintools:
+  set {SB::lang::at::isalreadyset::%{_lang}%} to "%{_s1}%There is already a bedrock or a island set. Kick everyone first and remove the bedrock, then create the new island."
+  set {SB::lang::at::isnowset::%{_lang}%} to "%{_s1}%The island is now set, add a island leader with /isadmin island addmember <new leader>."
 
-	#
-	# > Flags
-	#
-	
-	#
-	# > Flag titles
-	set {SB::lang::flag::explosiont::%{_lang}%} to "Explosionen"
-	set {SB::lang::flag::buttont::%{_lang}%} to "Knöpfe & Hebel"
-	set {SB::lang::flag::doort::%{_lang}%} to "Türen"
-	set {SB::lang::flag::mob-damaget::%{_lang}%} to "Monster"
-	set {SB::lang::flag::animal-damaget::%{_lang}%} to "Tiere"
-	set {SB::lang::flag::interact-vehiclet::%{_lang}%} to "Vehikel"
-	set {SB::lang::flag::publichomet::%{_lang}%} to "Zuhause"
-	set {SB::lang::flag::buildt::%{_lang}%} to "Bauen und abbauen"
-	set {SB::lang::flag::chestt::%{_lang}%} to "Blockinventare"
-	set {SB::lang::flag::entityclickt::%{_lang}%} to "Entities"
-	set {SB::lang::flag::flagst::%{_lang}%} to "&lFlags"
-	set {SB::lang::flag::foreignt::%{_lang}%} to "Flags für Fremde"
-	set {SB::lang::flag::trustedt::%{_lang}%} to "Flags für Vertraute"
-	set {SB::lang::flag::membert::%{_lang}%} to "Flags für Mitglieder"
-	
-	#
-	# > Flag descriptions
-	set {SB::lang::flag::explosiond::%{_lang}%} to "%{_s1}%Erlaubt zerstörerische\n%{_s1}%Explosionen an deiner\n%{_s1}%Insel."
-	set {SB::lang::flag::mob-spawningd::%{_lang}%} to "%{_s1}%Erlaubt das erscheinen\n%{_s1}%von Monstern auf\n%{_s1}%deiner Insel."
-	set {SB::lang::flag::buttond::%{_lang}%} to "%{_s1}%Erlaubt, die\n%{_s1}%Knöpfe auf deiner Insel\n%{_s1}%zu verwenden."
-	set {SB::lang::flag::doord::%{_lang}%} to "%{_s1}%Erlaubt, die\n%{_s1}%Türen auf deiner Insel\n%{_s1}%zu verwenden."
-	set {SB::lang::flag::mob-damaged::%{_lang}%} to "%{_s1}%Erlaubt, deine\n%{_s1}%Monster zu schlagen."
-	set {SB::lang::flag::animal-damaged::%{_lang}%} to "%{_s1}%Erlaubt, deine\n%{_s1}%Tiere zu schlagen."
-	set {SB::lang::flag::itemframe-damaged::%{_lang}%} to "%{_s1}%Erlaubt,\n%{_s1}%deine Rahmen abzubauen."
-	set {SB::lang::flag::interact-vehicled::%{_lang}%} to "%{_s1}%Erlaubt,\n%{_s1}%Vehikel zu verwenden."
-	set {SB::lang::flag::publichomed::%{_lang}%} to "%{_s1}%Erlaubt diesen Spielern,\n%{_s1}%deine Insel zu besuchen."
-	set {SB::lang::flag::buildd::%{_lang}%} to "%{_s1}%Erlaubt diesen Spielern,\n%{_s1}%auf deiner Insel zu bauen\n%{_s1}%und abzubauen."
-	set {SB::lang::flag::chestd::%{_lang}%} to "%{_s1}%Erlaubt diesen Spielern,\n%{_s1}%auf deiner Insel in die\n%{_s1}%Inventare von\n%{_s1}%von Blöcken zu schauen."
-	set {SB::lang::flag::entityclickd::%{_lang}%} to "%{_s1}%Erlaubt diesen Spielern,\n%{_s1}%Entities anzuklicken."
-	set {SB::lang::flag::foreignd::%{_lang}%} to "%{_s1}%Erlaube Fremden diverse\n%{_s1}%Aktionen auf deiner Insel\n%{_s1}%auszuführen, ändere\n%{_s1}%diese Einstellungen hier."
-	set {SB::lang::flag::trustedd::%{_lang}%} to "%{_s1}%Erlaube Vertrauten diverse\n%{_s1}%Aktionen auf deiner Insel\n%{_s1}%auszuführen, ändere\n%{_s1}%diese Einstellungen hier."
-	set {SB::lang::flag::memberd::%{_lang}%} to "%{_s1}%Erlaube Mitgliedern diverse\n%{_s1}%Aktionen auf deiner Insel\n%{_s1}%auszuführen, ändere\n%{_s1}%diese Einstellungen hier."
-	
-	#
-	# > Flag settings
-	set {SB::lang::flag::toggleflagstrue::%{_lang}%} to "%{_s1}%Diese Einstellung\n%{_s1}%kann geändert werden."
-	set {SB::lang::flag::toggleflagsfalse::%{_lang}%} to "%{_s1}%Diese Einstellung\n%{_s1}%kann nicht geändert werden."
-	set {SB::lang::flag::currentsetting::%{_lang}%} to "%{_s1}%Aktuelle Einstellung: "
-	set {SB::lang::flag::currenttrue::%{_lang}%} to "&2An"
-	set {SB::lang::flag::currentfalse::%{_lang}%} to "&4Aus"
-	set {SB::lang::flag::errorfalse::%{_lang}%} to "Der Besitzer hat diese Funktion abgeschaltet."
-	
-	#
-	# > Ore generator add-on
-	#
-	set {SB::lang::og::name::%{_lang}%} to "Erz Generator: "
-	set {SB::lang::og::currentlvl::%{_lang}%} to "Aktuelles Level: "
-	set {SB::lang::og::progress::%{_lang}%} to "Fortschritt: <c> / <n> Blöcke"
-	set {SB::lang::og::chancesforyou::%{_lang}%} to "Erz Generator Chancen für dich:"
+  #
+  # > Flags
+  #
+  
+  #
+  # > Flag titles
+  set {SB::lang::flag::explosiont::%{_lang}%} to "Explosionen"
+  set {SB::lang::flag::buttont::%{_lang}%} to "Knöpfe & Hebel"
+  set {SB::lang::flag::doort::%{_lang}%} to "Türen"
+  set {SB::lang::flag::mob-damaget::%{_lang}%} to "Monster"
+  set {SB::lang::flag::animal-damaget::%{_lang}%} to "Tiere"
+  set {SB::lang::flag::interact-vehiclet::%{_lang}%} to "Vehikel"
+  set {SB::lang::flag::publichomet::%{_lang}%} to "Zuhause"
+  set {SB::lang::flag::buildt::%{_lang}%} to "Bauen und abbauen"
+  set {SB::lang::flag::chestt::%{_lang}%} to "Blockinventare"
+  set {SB::lang::flag::entityclickt::%{_lang}%} to "Entities"
+  set {SB::lang::flag::redstonet::%{_lang}%} to "Redstone"
+  set {SB::lang::flag::flagst::%{_lang}%} to "&lFlags"
+  set {SB::lang::flag::foreignt::%{_lang}%} to "Flags für Fremde"
+  set {SB::lang::flag::trustedt::%{_lang}%} to "Flags für Vertraute"
+  set {SB::lang::flag::membert::%{_lang}%} to "Flags für Mitglieder"
+  
+  #
+  # > Flag descriptions
+  set {SB::lang::flag::explosiond::%{_lang}%} to "%{_s1}%Erlaubt zerstörerische\n%{_s1}%Explosionen an deiner\n%{_s1}%Insel."
+  set {SB::lang::flag::mob-spawningd::%{_lang}%} to "%{_s1}%Erlaubt das erscheinen\n%{_s1}%von Monstern auf\n%{_s1}%deiner Insel."
+  set {SB::lang::flag::buttond::%{_lang}%} to "%{_s1}%Erlaubt, die\n%{_s1}%Knöpfe auf deiner Insel\n%{_s1}%zu verwenden."
+  set {SB::lang::flag::doord::%{_lang}%} to "%{_s1}%Erlaubt, die\n%{_s1}%Türen auf deiner Insel\n%{_s1}%zu verwenden."
+  set {SB::lang::flag::mob-damaged::%{_lang}%} to "%{_s1}%Erlaubt, deine\n%{_s1}%Monster zu schlagen."
+  set {SB::lang::flag::animal-damaged::%{_lang}%} to "%{_s1}%Erlaubt, deine\n%{_s1}%Tiere zu schlagen."
+  set {SB::lang::flag::itemframe-damaged::%{_lang}%} to "%{_s1}%Erlaubt,\n%{_s1}%deine Rahmen abzubauen."
+  set {SB::lang::flag::interact-vehicled::%{_lang}%} to "%{_s1}%Erlaubt,\n%{_s1}%Vehikel zu verwenden."
+  set {SB::lang::flag::publichomed::%{_lang}%} to "%{_s1}%Erlaubt diesen Spielern,\n%{_s1}%deine Insel zu besuchen."
+  set {SB::lang::flag::buildd::%{_lang}%} to "%{_s1}%Erlaubt diesen Spielern,\n%{_s1}%auf deiner Insel zu bauen\n%{_s1}%und abzubauen."
+  set {SB::lang::flag::chestd::%{_lang}%} to "%{_s1}%Erlaubt diesen Spielern,\n%{_s1}%auf deiner Insel in die\n%{_s1}%Inventare von\n%{_s1}%von Blöcken zu schauen."
+  set {SB::lang::flag::entityclickd::%{_lang}%} to "%{_s1}%Erlaubt diesen Spielern,\n%{_s1}%Entities anzuklicken."
+  set {SB::lang::flag::redstoned::%{_lang}%} to "%{_s1}%Erlaubt diesen Spielern,\n%{_s1}%Redstone Einstellungen\n%{_s1}%zu ändern."
+  set {SB::lang::flag::foreignd::%{_lang}%} to "%{_s1}%Erlaube Fremden diverse\n%{_s1}%Aktionen auf deiner Insel\n%{_s1}%auszuführen, ändere\n%{_s1}%diese Einstellungen hier."
+  set {SB::lang::flag::trustedd::%{_lang}%} to "%{_s1}%Erlaube Vertrauten diverse\n%{_s1}%Aktionen auf deiner Insel\n%{_s1}%auszuführen, ändere\n%{_s1}%diese Einstellungen hier."
+  set {SB::lang::flag::memberd::%{_lang}%} to "%{_s1}%Erlaube Mitgliedern diverse\n%{_s1}%Aktionen auf deiner Insel\n%{_s1}%auszuführen, ändere\n%{_s1}%diese Einstellungen hier."
+  
+  #
+  # > Flag settings
+  set {SB::lang::flag::toggleflagstrue::%{_lang}%} to "%{_s1}%Diese Einstellung\n%{_s1}%kann geändert werden."
+  set {SB::lang::flag::toggleflagsfalse::%{_lang}%} to "%{_s1}%Diese Einstellung\n%{_s1}%kann nicht geändert werden."
+  set {SB::lang::flag::currentsetting::%{_lang}%} to "%{_s1}%Aktuelle Einstellung: "
+  set {SB::lang::flag::currenttrue::%{_lang}%} to "&2An"
+  set {SB::lang::flag::currentfalse::%{_lang}%} to "&4Aus"
+  set {SB::lang::flag::errorfalse::%{_lang}%} to "Der Besitzer hat diese Funktion abgeschaltet."
+  
+  #
+  # > Ore generator add-on
+  #
+  set {SB::lang::og::name::%{_lang}%} to "Erz Generator: "
+  set {SB::lang::og::currentlvl::%{_lang}%} to "Aktuelles Level: "
+  set {SB::lang::og::progress::%{_lang}%} to "Fortschritt: <c> / <n> Blöcke"
+  set {SB::lang::og::chancesforyou::%{_lang}%} to "Erz Generator Chancen für dich:"
 
-	#
-	# > Biome change add-on
-	set {SB::lang::bc::changing::%{_lang}%} to "Ändere das Biom zu: <biome>"
-	set {SB::lang::bc::done::%{_lang}%} to "Biomänderung abgeschlossen."
-	set {SB::lang::bc::changebiomeheader::%{_lang}%} to "Biom ändern"
-	set {SB::lang::bc::changebiomemenulore::%{_lang}%} to "&rÄndere dein Biom"
-	set {SB::lang::bc::shopprice::%{_lang}%} to "Preis: <price>"
-	set {SB::lang::bc::shopfree::%{_lang}%} to "Kostenlos"
-	set {SB::lang::bc::notenoughmoney::%{_lang}%} to "Du hast nicht genug Geld dafür."
+  #
+  # > Biome change add-on
+  set {SB::lang::bc::changing::%{_lang}%} to "Ändere das Biom zu: <biome>"
+  set {SB::lang::bc::done::%{_lang}%} to "Biomänderung abgeschlossen."
+  set {SB::lang::bc::changebiomeheader::%{_lang}%} to "Biom ändern"
+  set {SB::lang::bc::changebiomemenulore::%{_lang}%} to "&rÄndere dein Biom"
+  set {SB::lang::bc::shopprice::%{_lang}%} to "Preis: <price>"
+  set {SB::lang::bc::shopfree::%{_lang}%} to "Kostenlos"
+  set {SB::lang::bc::notenoughmoney::%{_lang}%} to "Du hast nicht genug Geld dafür."
 
-	#
-	# > Island upgrades
-	set {SB::lang::bc::islandsizeshop::%{_lang}%} to "Vergrößert deine Insel\nauf <size>x<size> Blöcke."
-	set {SB::lang::bc::islandsizetitle::%{_lang}%} to "Inselgröße "
-	set {SB::lang::bc::islandhoppertitle::%{_lang}%} to "Trichter "
-	set {SB::lang::bc::islandhometitle::%{_lang}%} to "Zuhause "
-	set {SB::lang::bc::islandhoppershop::%{_lang}%} to "Erlaubt dir insgesamt\n<size> Trichter zu setzen."
-	set {SB::lang::bc::islandhopperlimitinfo::%{_lang}%} to "Du kannst nur <size> Trichter setzen."
-	set {SB::lang::bc::islandhomeshop::%{_lang}%} to "Erlaubt dir insgesamt\n<size> Homes zu setzen."
-	set {SB::lang::bc::islandupgrades::%{_lang}%} to "Insel Erweiterungen"
-	
-	#
-	# > Island item binding
-	set {SB::lang::islandbound::%{_lang}%} to "Inselgebunden"
-	set {SB::lang::boundtoanotherisland::%{_lang}%} to "Dieser Block ist an eine andere Insel gebunden."
+  #
+  # > Island upgrades
+  set {SB::lang::bc::islandsizeshop::%{_lang}%} to "Vergrößert deine Insel\nauf <size>x<size> Blöcke."
+  set {SB::lang::bc::islandsizetitle::%{_lang}%} to "Inselgröße "
+  set {SB::lang::bc::islandhoppertitle::%{_lang}%} to "Trichter "
+  set {SB::lang::bc::islandhometitle::%{_lang}%} to "Zuhause "
+  set {SB::lang::bc::islandhoppershop::%{_lang}%} to "Erlaubt dir insgesamt\n<size> Trichter zu setzen."
+  set {SB::lang::bc::islandhopperlimitinfo::%{_lang}%} to "Du kannst nur <size> Trichter setzen."
+  set {SB::lang::bc::islandhomeshop::%{_lang}%} to "Erlaubt dir insgesamt\n<size> Homes zu setzen."
+  set {SB::lang::bc::islandupgrades::%{_lang}%} to "Insel Erweiterungen"
+  
+  #
+  # > Island item binding
+  set {SB::lang::islandbound::%{_lang}%} to "Inselgebunden"
+  set {SB::lang::boundtoanotherisland::%{_lang}%} to "Dieser Block ist an eine andere Insel gebunden."


### PR DESCRIPTION
This flag is necessary if a player only wants to give specific rights to trusted players to change or deny to change redstone repeaters, comparators or daylight sensors.

This pull request solves this issue: https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/79