### PR TITLE
Load chunks while calculating the island

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Functions/calcisland.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/calcisland.sk
@@ -48,6 +48,9 @@ function calcisland(p:offline player):
     add 1 to {_i}
     add 1 to {_b}
     #
+    # > Setting the chunk of the current loop block to a local variable to load the chunk
+    set {_lb} to chunk at loop-block
+    #
     # > Every 10000 blocks, check for new percentages for the progress bar.
     if {_i} is 10000:
       set {_percent} to ({_b}/{_size})*100


### PR DESCRIPTION
This prevents hanging. It seems that this caused some problems in the past.

Some players experienced that the ```/island calc``` command hangs sometimes, this might happened because some chunks where not loaded. With this change, chunks are now loaded into a local variable and keep loaded until the process is done.

This issue is now solved: https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/89