### PR TITLE
Added custom armor stands addon

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Functions/challenges.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/challenges.sk
@@ -183,6 +183,7 @@ function openchallenges(p:player):
         #
         # > The slot is not available, display a black glass pane instead.
         set slot {_slot} of {_p}'s current inventory to black glass pane named "%{_lvltranslation}%"
+        protectslot({_p},{_slot})
       #
 	  # > The challenge level part loop ends here, add 1 to the slot and challenge level part.
       add 1 to {_slot}
@@ -199,6 +200,7 @@ function openchallenges(p:player):
     else:
       set lore of {_head} to "%{SB::lang::challenge::xpneeded::%{_lang}%}%||%{SB::config::guispacer}%||&r%{_xp}%/%{SB::config::challenges::threshold::%{_challengelvl}%}%||%{SB::config::guispacer}%||%{SB::lang::challenge::xpionlywclvl::%{_lang}%}%"
     set slot {_slot} of {_p}'s current inventory to {_head}
+    protectslot({_p},{_slot})
     add 1 to {_slot}
     add 1 to {_challengelvl}
     #
@@ -332,7 +334,9 @@ function solvechallenge(p:player,challenge:text):
   # > If there is a custom function set for this challenge, execute it with evaluate.
   if {SB::config::challenges::c::%{_challenge}%::customfunction} is set:
     if {SB::config::challenges::c::%{_challenge}%::customfunction} is not "":
-      evaluate "%{SB::config::challenges::c::%{_challenge}%::customfunction}%"
+      set {_exec} to {SB::config::challenges::c::%{_challenge}%::customfunction}
+      replace all "<player>" with "%{_p}%" in {_exec}
+      evaluate "%{_exec}%"
   #
   # > Add experience to the island of the player.
   if {_xp} is set:

--- a/SkyBlock/SKYBLOCK.SK/Functions/createisland.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/createisland.sk
@@ -36,6 +36,7 @@ function createisland(p:player,island:text="1"):
       # > Empty slots are displayed with black stained glass panes for better look.
       loop 27 times:
         set slot loop-number - 1 of {_p}'s current inventory to black stained glass pane named " "
+        protectslot({_p},loop-number - 1)
       #
       # > Start with the list in the menu at this slot.
       set {_slot} to 10

--- a/SkyBlock/SKYBLOCK.SK/Functions/islandupgrademenu.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/islandupgrademenu.sk
@@ -36,10 +36,9 @@ function islandupgrademenu(p:player):
   if {SB::island::%{_x}%_%{_y}%_%{_z}%::leader} is {_uuid}:
     set {_slots} to 54
     opengui({_p},{_slots},"&l%{SB::lang::bc::islandupgrades::%{_lang}%}%")
-    set {_i} to 0
-    loop 57 times:
-      set slot {_i} of {_p}'s current inventory to black glass pane named " "
-      add 1 to {_i}
+    loop {_slots} times:
+      set slot loop-number - 1 of {_p}'s current inventory to black glass pane named " "
+      protectslot({_p},loop-number - 1)
     #
     # > Set {_i} to 0, to order the items in the menu right.
     set {_i} to 1

--- a/SkyBlock/SKYBLOCK.SK/Functions/islandupgrademenu.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/islandupgrademenu.sk
@@ -40,6 +40,10 @@ function islandupgrademenu(p:player):
       set slot loop-number - 1 of {_p}'s current inventory to black glass pane named " "
       protectslot({_p},loop-number - 1)
     #
+    # > Set back item to get to the previous menu.
+    setguiitem({_p},{_slots}-1,{SB::config::backguiitem},1,"&r%{SB::lang::guibacktopreviousmenu::%{SK::lang::%{_uuid}%}%}%","%{SB::lang::guibacktopreviousmenulore::%{SK::lang::%{_uuid}%}%}%","make ""%{_p}%"" parsed as player execute command ""/is""",true)
+
+    #
     # > Set {_i} to 0, to order the items in the menu right.
     set {_i} to 1
     set {_lvl} to 0

--- a/SkyBlock/SKYBLOCK.SK/Functions/loadconfig.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/loadconfig.sk
@@ -10,12 +10,10 @@
 # > Actions:
 # > Calls functions to load configurations.
 on load:
+  wait 1 second
   #
   # > Load the yaml configurations using the loadconfig function.
   loadconfig()
-  #
-  # > Functions to start after config loaded, do not change this if you don't know what you're doing.
-  loadislandstoworld()
 
 #
 # > Function - loadymlparsenumber

--- a/SkyBlock/SKYBLOCK.SK/Functions/menues.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/menues.sk
@@ -52,6 +52,7 @@ function skyblockgui(p: player):
   setguiitem({_p},16,jungle leaves,1,"&r&6&l%{SB::lang::bc::changebiomeheader::%{_lang}%}%","&r%{SB::lang::bc::changebiomemenulore::%{_lang}%}%","make ""%{_p}%"" parsed as player execute command ""/is biome""",true)
   setguiitem({_p},19,{_customgui},1,"&r&6&l%{SB::lang::languages::%{_lang}%}%","&r%{SB::lang::maingui::guilanglore::%{_lang}%}%","make ""%{_p}%"" parsed as player execute command ""/is lang""",true)
   setguiitem({_p},20,lever,1,"&r&6&l%{SB::lang::flag::flagst::%{_lang}%}%","&r%{SB::lang::maingui::guiflaglore::%{_lang}%}%","make ""%{_p}%"" parsed as player execute command ""/is flags""",true)
+  setguiitem({_p},21,hopper,1,"&r&6&l%{SB::lang::bc::islandupgrades::%{_lang}%}%","&r%{SB::lang::maingui::islandupgradelore::%{_lang}%}%","make ""%{_p}%"" parsed as player execute command ""/is upgrades""",true)
 #
 # > Function - biomemenu:
 # > Arguments:

--- a/SkyBlock/SKYBLOCK.SK/Functions/menues.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/menues.sk
@@ -20,6 +20,7 @@ function skyblockgui(p: player):
   # > Fill the Inventory with empty glass panes.
   loop 36 times:
     set slot loop-number - 1 of {_p}'s current inventory to black stained glass pane named " "
+    protectslot({_p},loop-number - 1)
   #
   # > Set frequently used data into local variables.
   set {_uuid} to uuid of {_p}
@@ -84,6 +85,7 @@ function biomemenu(p: player):
     # > Fill the inventory with empty glass panes to make it look nicer
     loop {_slots} times:
       set slot loop-number - 1 of {_p}'s current inventory to black stained glass pane named " "
+      protectslot({_p},loop-number - 1)
     #
     # > Render all the biomes into the menu, they can be changed in the config.sk
     set {_slot} to 10

--- a/SkyBlock/SKYBLOCK.SK/Functions/openflagmenu.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/openflagmenu.sk
@@ -28,6 +28,7 @@ function openflagmenu(p:player,type:text):
     # > Empty slots are shown as black stained glass.
     loop 27 times:
       set slot loop-number - 1 of {_p}'s current inventory to black stained glass pane named " "
+      protectslot({_p},loop-number - 1)
 
     setguiitem({_p},11,farmland,1,"&r%{SB::lang::flag::foreignt::%{_lang}%}%","&r%{SB::lang::flag::foreignd::%{_lang}%}%","openflagmenu(""%{_p}%"" parsed as player,""foreign"")",false)
     setguiitem({_p},13,grass path,1,"&r%{SB::lang::flag::trustedt::%{_lang}%}%","&r%{SB::lang::flag::trustedd::%{_lang}%}%","openflagmenu(""%{_p}%"" parsed as player,""trusted"")",false)
@@ -62,6 +63,7 @@ function openflagmenu(p:player,type:text):
     # > Empty slots are shown as black stained glass.
     loop {_slots} times:
       set slot loop-number - 1 of {_p}'s current inventory to black stained glass pane named " "
+      protectslot({_p},loop-number - 1)
 
     #
     # > Set {_i} to 10, to order the items in the menu right.

--- a/SkyBlock/SKYBLOCK.SK/Functions/selectlanguage.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/selectlanguage.sk
@@ -26,6 +26,7 @@ function selectlanguage(p:player):
   # > Empty slots are shown as black stained glass.
   loop 27 times:
     set slot loop-number - 1 of {_p}'s current inventory to black stained glass pane named " "
+    protectslot({_p},loop-number - 1)
   #
   # > Set slot id, for the following loop.
   set {_slot} to 10

--- a/SkyBlock/addons/customarmorstands.sk
+++ b/SkyBlock/addons/customarmorstands.sk
@@ -135,6 +135,23 @@ function checkarmorstandplacepermission(player:player,location:location) :: bool
 	return checkislandaccess({_player},{_location})
 
 #
+# > Function - checkarmorstandblacklist
+# > Parameters:
+# > <entity>the armor stand
+# > Actions:
+# > This function should only return true if it is not being used by
+# > other plugins or addons. Add these armor stands here to the blacklist
+# > to support these armor stands. Feel free to open a issue if you don't
+# > know how this could be done.
+function checkarmorstandblacklist(entity:entity) :: boolean:
+	#
+	# > Check for robots.sk armor stands.
+	set {_check} to getnbtvalue(helmet of {_entity},"blocks")
+	if {_check} is not false:
+		return false
+	return true
+
+#
 # > Event - on rightclick holding the predefined copy tool
 # > Actions:
 # > Creates a copy of the already created armor stand which is
@@ -237,6 +254,8 @@ command /renamestand [<text>]:
 		if {_target} is a armor stand:
 			if checkarmorstandplacepermission(player,{_target}'s location) is not true:
 				stop
+			if checkarmorstandblacklist({_target}) is not true:
+				stop
 			if length of arg-1 <= 20:
 				{_target}.setCustomName(colored arg-1)
 
@@ -252,7 +271,8 @@ function opencustomstandmenu(player:player):
 	set {_target} to metadata value "customarmorstand-target" of {_player}
 	if checkarmorstandplacepermission({_player},{_target}'s location) is not true:
 		stop
-
+	if checkarmorstandblacklist({_target}) is not true:
+		stop
 	#
 	# > Get the translation for the menu.
 	set {_uuid} to uuid of {_player}

--- a/SkyBlock/addons/customarmorstands.sk
+++ b/SkyBlock/addons/customarmorstands.sk
@@ -1,0 +1,854 @@
+#
+# ==============
+# customarmorstands.sk v0.0.1
+# ==============
+# Allow your players to edit their armor stands with ease.
+# ==============
+# Dependencies
+# ==============
+# > Spigot 1.13.2 - https://hub.spigotmc.org/jenkins/job/BuildTools/
+# > Skript by bensku - https://github.com/SkriptLang/Skript/releases
+# > skript-mirror - https://github.com/btk5h/skript-mirror/releases
+# > gui.sk - https://github.com/Abwasserrohr/SKYBLOCK.SK/blob/master/SkyBlock/addons/gui.sk
+# > robots.sk - https://github.com/Abwasserrohr/SKYBLOCK.SK/blob/master/SkyBlock/addons/robots.sk
+# ==============
+# How to use it:
+# ==============
+# > Add customarmorstands.sk to your "plugins/Skript/scripts" folder and then reload.
+# > Every armor stand can be changed if the player has the permission at the location.
+# > Change the "checkarmorstandplacepermission" function to fit your protection system.
+# > Predefined to work with SKYBLOCK.SK.
+# --------------
+#
+# > Change these options as you want. They are meant to be changed.
+options:
+	#
+	# > Permissions:
+	#
+	# > This permission allows to place and break any armor stand.
+	adminpermission: is.admin
+	#
+	# > This permission allows to get the clone tool to duplicate
+	# > armor stands. This is only suitable for creative servers.
+	clonepermission: is.admin
+	#
+	# > The copy tool which is given to the player if a armor stand gets
+	# > removed or cloned.
+	copytool: stick
+	#
+	# > Menu background item
+	backgrounditem: black stained glass pane
+	#
+	# > No item selected item
+	noitemselecteditem: white stained glass pane
+	#
+	# > X coordinate item
+	xcoorditem: red wool
+	#
+	# > Y coordinate item
+	ycoorditem: green wool
+	#
+	# > Z coordinate item
+	zcoorditem: blue wool
+	#
+	# > Change direction item
+	directionitem: magenta glazed terracotta
+	#
+	# > Clone item
+	cloneitem: armor stand
+	#
+	# > Toggle size item
+	togglesizeitem: red mushroom
+	#
+	# > Toggle visibility item
+	togglevisibilityitem: water bottle
+	#
+	# > Toggle glow item
+	toggleglowitem: glowstone block
+	#
+	# > Toggle baseplate item
+	togglebaseplateitem: stone slab
+	#
+	# > Toglle arms item
+	togglearmsitem: stick
+	#
+	# > Toggle name visibility item
+	togglenamevisibilityitem: name tag
+	#
+	# > Remove armor stand item
+	removearmorstanditem: barrier
+	#
+	# > Fallback translations - These get used if there is no SKYBLOCK.SK
+	# > language file loaded. You can find these language files here: 
+	# > https://github.com/Abwasserrohr/SKYBLOCK.SK/tree/master/SkyBlock/lang
+	guiheader: &lCustom Stands
+	head: &rHead
+	body: &rBody
+	legs: &rLegs
+	rightleg: &rRight leg
+	leftleg: &rLeft leg
+	rightarm: &rRight arm
+	leftarm: &rLeft arm
+	feet: &rFeet
+	xcoord: &rChange &cX&r Coordinate
+	ycoord: &rChange &2Y&r Coordinate
+	zcoord: &rChange &bZ&r Coordinate
+	placeitemslot: &7Place here the item\n&7you want for this slot.
+	copytoolname: &rCopy Stick
+	copytoollore: &7This tool only copies\n&7the armor stand temporary,\n&7do not use it to\n&7store for long term.
+	togglesize: &rSize
+	togglesizelore: &7Toggle the size\n&7between big and small.
+	togglevisibility: &rVisibility
+	togglevisibilitylore: &7Toggle the visibility\n&7of this armor stand.
+	toggleglow: &rGlow
+	toggleglowlore: &7Toggle the glow\n&7of the armor stand.
+	togglebaseplate: &rBaseplate
+	togglebaseplatelore: &7Toggle the baseplate\n&7of the armor stand.
+	togglearms: &rArms
+	togglearmslore: &7Toggle the arms\n&7of the armor stand.
+	changedirection: &rDirection
+	changedirectionlore: &rChange the direction\n&7of the armor stand.
+	copyarmorstand: &rCopy
+	copyarmorstandlore: &7Copy the armor stand.
+	togglename: &rName
+	togglenamelore: &7Toggle the name\n&7between visible and invisible.\n&7Customize the name\n&7with /renamestand <text>.
+	removearmorstand: &rRemove
+	removearmorstandlore: &7Remove this armor stand\n&7and get a copy of it\n&7to replace the armor stand.
+	#
+	# > Please note: You may want to change the function "checkarmorstandplacepermission" below to fit
+	# > it into your protections system. It should return true if the player is allowed to change the armor stand.
+
+#
+# > Function - checkarmorstandplacepermission
+# > Parameters:
+# > <player>player
+# > Actions:
+# > Feel free to change this function to fit your server.
+# > If this function returns true, the user is allowed to
+# > place, modify and remove the armor stands.
+function checkarmorstandplacepermission(player:player,location:location) :: boolean:
+	if {_player} has permission "{@adminpermission}":
+		return true
+	#
+	# > Use SKYBLOCK.SK function to determine if the player is allowed.
+	return checkislandaccess({_player},{_location})
+
+#
+# > Event - on rightclick holding the predefined copy tool
+# > Actions:
+# > Creates a copy of the already created armor stand which is
+# > stored as metadata.
+on rightclick holding {@copytool}:
+	set {_copytool} to getnbtvalue(player's tool,"customstand")
+	if {_copytool} is not "":
+		cancel event
+		set {_loc} to location of player's target block
+		add 0.5 to y-coordinate of {_loc}
+		if checkarmorstandplacepermission(player,{_loc}) is not true:
+			stop
+		set {_target} to metadata value "%{_copytool}%" of player
+		if player's gamemode is not creative:
+			remove 1 of player's tool from player's inventory
+		spawn 1 armor stand at {_loc}
+		set {_robo} to last spawned entity
+		{_robo}.setGravity(false)
+		{_robo}.setBasePlate({_target}.hasBasePlate())
+		{_robo}.setCanPickupItems(false)
+		{_robo}.setCustomName({_target}.getCustomName())
+		{_robo}.setCustomNameVisible({_target}.isCustomNameVisible())
+		{_robo}.setVisible({_target}.isVisible())
+		{_robo}.setSmall({_target}.isSmall())
+		{_robo}.setArms({_target}.hasArms())
+		{_robo}.setInvulnerable(true)
+		{_robo}.setGlowing({_target}.isGlowing())
+		
+		{_robo}.setHelmet({_target}.getHelmet())
+		{_robo}.setChestplate({_target}.getChestplate())
+		{_robo}.setLeggings({_target}.getLeggings())
+		{_robo}.setBoots({_target}.getBoots())
+		set {_robo}'s offhand tool to {_target}'s offhand tool
+		set {_robo}'s tool to {_target}'s tool
+		
+		{_robo}.setHeadPose({_target}.getHeadPose())
+		{_robo}.setBodyPose({_target}.getBodyPose())
+		{_robo}.setRightArmPose({_target}.getRightArmPose())
+		{_robo}.setLeftArmPose({_target}.getLeftArmPose())
+		{_robo}.setRightLegPose({_target}.getRightLegPose())
+		{_robo}.setLeftLegPose({_target}.getLeftLegPose())
+
+#
+# > On rightclick holding an armor stand
+# > Actions:
+# > If a player rightclicks holding a armor stand,
+# > a custom armor stand is placed which has special settings.
+on rightclick:
+	if player's tool is a armor stand:
+		cancel event
+		#
+		# > Set the location where the armor stand should be spawned.
+		set {_loc} to location of player's target block
+		add 0.5 to y-coordinate of {_loc}
+		#
+		# > Check if the player is allowed to place the armor stand at this location.
+		if checkarmorstandplacepermission(player,{_loc}) is not true:
+			stop
+		if gamemode of player is not creative:
+			remove 1 of player's tool from player's inventory
+		#
+		# > Spawn the armor stand at the location.
+		spawn 1 armor stand at {_loc}
+		#
+		# > Get the armor stand in a variable, which has been spawned above.
+		set {_stand} to last spawned entity
+
+		{_stand}.setGravity(false)
+		{_stand}.setCanPickupItems(false)
+		{_stand}.setVisible(true)
+		{_stand}.setInvulnerable(true)
+
+#
+# > Import a Java class from bukkit to catch the PlayerInteractAtEntityEvent event.
+import:
+	org.bukkit.event.player.PlayerInteractAtEntityEvent
+	java.util.UUID
+
+#
+# > Event - PlayerInteractAtEntityEvent
+# > Actions:
+# > If the entitiy is a armor stand, cancel the event and call the opencustomstandmenu
+# > function. Also sets the entity as a metadata value into the player.
+on PlayerInteractAtEntityEvent:
+	if event.getRightClicked() is armor stand:
+		set metadata "customarmorstand-target" of event.getPlayer() to event.getRightClicked()
+		opencustomstandmenu(event.getPlayer())
+		cancel event
+
+#
+# > Command - /renamestand
+# > Arugments:
+# > <text>name of the armor stand
+# > Actions:
+# > Renames the armor stand if the player is allowed to do it and if the name has
+# > a length of 20 or smaller.
+command /renamestand [<text>]:
+	trigger:
+		set {_target} to player's target
+		if {_target} is a armor stand:
+			if checkarmorstandplacepermission(player,{_target}'s location) is not true:
+				stop
+			if length of arg-1 <= 20:
+				{_target}.setCustomName(colored arg-1)
+
+#
+# > Function - opencustomstandmenu
+# > Parameters:
+# > <player>player
+# > Actions:
+# > Opens the custom armor stand menu. All functions are called through this menu and
+# > it has multilanguage support from SKYBLOCK.SK.
+function opencustomstandmenu(player:player):
+
+	set {_target} to metadata value "customarmorstand-target" of {_player}
+	if checkarmorstandplacepermission({_player},{_target}'s location) is not true:
+		stop
+
+	#
+	# > Get the translation for the menu.
+	set {_uuid} to uuid of {_player}
+	set {_lang} to {SK::lang::%{_uuid}%}
+	#
+	# > If the translation isn't set, use the fallback one.
+	if {SB::lang::cs::guiheader::%{_lang}%} is not set:
+		set {_headerlang} to "{@guiheader}"
+		set {_headlang} to "{@head}"
+		set {_bodylang} to "{@body}"
+		set {_legslang} to "{@legs}"
+		set {_feetlang} to "{@feet}"
+		set {_rightleglang} to "{@rightleg}"
+		set {_leftleglang} to "{@leftleg}"
+		set {_rightarmlang} to "{@rightarm}"
+		set {_leftarmlang} to "{@leftarm}"
+		set {_xlang} to "{@xcoord}"
+		set {_ylang} to "{@ycoord}"
+		set {_zlang} to "{@zcoord}"
+		set {_placeslotlang} to "{@placeitemslot}"
+		set {_togglesizelang} to "{@togglesize}"
+		set {_togglesizelorelang} to "{@togglesizelore}"
+		set {_togglevisibilitylang} to "{@togglevisibility}"
+		set {_togglevisibilitylorelang} to "{@togglevisibilitylore}"
+		set {_toggleglowlang} to "{@toggleglow}"
+		set {_toggleglowlorelang} to "{@toggleglowlore}"
+		set {_togglebaseplatelang} to "{@togglebaseplate}"
+		set {_togglebaseplatelorelang} to "{@togglebaseplatelore}"
+		set {_togglearmslang} to "{@togglearms}"
+		set {_togglearmslorelang} to "{@togglearmslore}"
+		set {_changedirectionlang} to "{@changedirection}"
+		set {_changedirectionlorelang} to "{@changedirectionlore}"
+		set {_copyarmorstandlang} to "{@copyarmorstand}"
+		set {_copyarmorstandlorelang} to "{@copyarmorstandlore}"
+		set {_togglenamelang} to "{@togglename}"
+		set {_togglenamelorelang} to "{@togglenamelore}"
+		set {_removearmorstandlang} to "{@removearmorstand}"
+		set {_removearmorstandlorelang} to "{@removearmorstandlore}"
+	#
+	# > The translation is available, use it.
+	else:
+		set {_headerlang} to {SB::lang::cs::guiheader::%{_lang}%}
+		set {_headlang} to {SB::lang::cs::head::%{_lang}%}
+		set {_bodylang} to {SB::lang::cs::body::%{_lang}%}
+		set {_legslang} to {SB::lang::cs::legs::%{_lang}%}
+		set {_feetlang} to {SB::lang::cs::feet::%{_lang}%}
+		set {_rightleglang} to {SB::lang::cs::rightleg::%{_lang}%}
+		set {_leftleglang} to {SB::lang::cs::leftleg::%{_lang}%}
+		set {_rightarmlang} to {SB::lang::cs::rightarm::%{_lang}%}
+		set {_leftarmlang} to {SB::lang::cs::leftarm::%{_lang}%}
+		set {_xlang} to {SB::lang::cs::xcoord::%{_lang}%}
+		set {_ylang} to {SB::lang::cs::ycoord::%{_lang}%}
+		set {_zlang} to {SB::lang::cs::zcoord::%{_lang}%}
+		set {_placeslotlang} to {SB::lang::cs::placeitemslot::%{_lang}%}
+		set {_togglesizelang} to {SB::lang::cs::togglesize::%{_lang}%}
+		set {_togglesizelorelang} to {SB::lang::cs::togglesizelore::%{_lang}%}
+		set {_togglevisibilitylang} to {SB::lang::cs::togglevisibility::%{_lang}%}
+		set {_togglevisibilitylorelang} to {SB::lang::cs::togglevisibilitylore::%{_lang}%}
+		set {_toggleglowlang} to {SB::lang::cs::toggleglow::%{_lang}%}
+		set {_toggleglowlorelang} to {SB::lang::cs::toggleglowlore::%{_lang}%}
+		set {_togglebaseplatelang} to {SB::lang::cs::togglebaseplate::%{_lang}%}
+		set {_togglebaseplatelorelang} to {SB::lang::cs::togglebaseplatelore::%{_lang}%}
+		set {_togglearmslang} to {SB::lang::cs::togglearms::%{_lang}%}
+		set {_togglearmslorelang} to {SB::lang::cs::togglearmslore::%{_lang}%}
+		set {_changedirectionlang} to {SB::lang::cs::changedirection::%{_lang}%}
+		set {_changedirectionlorelang} to {SB::lang::cs::changedirectionlore::%{_lang}%}
+		set {_copyarmorstandlang} to {SB::lang::cs::copyarmorstand::%{_lang}%}
+		set {_copyarmorstandlorelang} to {SB::lang::cs::copyarmorstandlore::%{_lang}%}
+		set {_togglenamelang} to {SB::lang::cs::togglename::%{_lang}%}
+		set {_togglenamelorelang} to {SB::lang::cs::togglenamelore::%{_lang}%}
+		set {_removearmorstandlang} to {SB::lang::cs::removearmorstand::%{_lang}%}
+		set {_removearmorstandlorelang} to {SB::lang::cs::removearmorstandlore::%{_lang}%}
+	#
+	# > Only open the inventory, if it hasn't been opened.
+	if name of {_player}'s current inventory is not {_headerlang}:
+		opengui({_player},54,{_headerlang})
+	#
+	# > Fill the Inventory with empty glass panes.
+	loop 54 times:
+		setguiitem({_player},loop-number - 1,{@backgrounditem},1," "," ","",false)
+	#
+	# > Once a player clicks on one of these menu items, the functions defined in these are
+	# > called. This addon needs gui.sk to work.
+	#
+	# > Head
+	setguiitem({_player},0,leather helmet,1,"%{_headlang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""head"")",false)
+	if {_target}.getHelmet() is air:
+		setguiitem({_player},1,{@noitemselecteditem},1,"%{_headlang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""head"")",false)
+	else:
+		set {_item} to {_target}.getHelmet()
+		setguiitem({_player},1,{_item},1,"%{_headlang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""head"")",false)
+	#
+	# > Head coordinate items
+	setguiitem({_player},3,{@xcoorditem},1,"%{_headlang}%",{_xlang},"starteditcustomstand(""%{_player}%"" parsed as player,""head"",""x"")",true)
+	setguiitem({_player},4,{@ycoorditem},1,"%{_headlang}%",{_ylang},"starteditcustomstand(""%{_player}%"" parsed as player,""head"",""y"")",true)
+	setguiitem({_player},5,{@zcoorditem},1,"%{_headlang}%",{_zlang},"starteditcustomstand(""%{_player}%"" parsed as player,""head"",""z"")",true)
+	#
+	# > Body
+	setguiitem({_player},9,leather chestplate,1,"%{_bodylang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""body"")",false)
+	if {_target}.getChestplate() is air:
+		setguiitem({_player},10,{@noitemselecteditem},1,"%{_bodylang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""body"")",false)
+	else:
+		set {_item} to {_target}.getChestplate()
+		setguiitem({_player},10,{_item},1,"%{_bodylang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""body"")",false)
+	#
+	# > Body coordinate items
+	setguiitem({_player},12,{@xcoorditem},1,"%{_bodylang}%",{_xlang},"starteditcustomstand(""%{_player}%"" parsed as player,""body"",""x"")",true)
+	setguiitem({_player},13,{@ycoorditem},1,"%{_bodylang}%",{_ylang},"starteditcustomstand(""%{_player}%"" parsed as player,""body"",""y"")",true)
+	setguiitem({_player},14,{@zcoorditem},1,"%{_bodylang}%",{_zlang},"starteditcustomstand(""%{_player}%"" parsed as player,""body"",""z"")",true)
+	#
+	# > Legs
+	setguiitem({_player},18,leather leggings,1,"%{_legslang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""leg"")",false)
+	if {_target}.getLeggings() is air:
+		setguiitem({_player},19,{@noitemselecteditem},1,"%{_legslang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""leg"")",false)
+	else:
+		set {_item} to {_target}.getLeggings()
+		setguiitem({_player},19,{_item},1,"%{_legslang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""leg"")",false)
+	#
+	# > Right leg coordinate items
+	setguiitem({_player},21,{@xcoorditem},1,{_rightleglang},{_xlang},"starteditcustomstand(""%{_player}%"" parsed as player,""rightleg"",""x"")",true)
+	setguiitem({_player},22,{@ycoorditem},1,{_rightleglang},{_ylang},"starteditcustomstand(""%{_player}%"" parsed as player,""rightleg"",""y"")",true)
+	setguiitem({_player},23,{@zcoorditem},1,{_rightleglang},{_zlang},"starteditcustomstand(""%{_player}%"" parsed as player,""rightleg"",""z"")",true)
+	#
+	# > Left leg coordinate items
+	setguiitem({_player},30,{@xcoorditem},1,{_leftleglang},{_xlang},"starteditcustomstand(""%{_player}%"" parsed as player,""leftleg"",""x"")",true)
+	setguiitem({_player},31,{@ycoorditem},1,{_leftleglang},{_ylang},"starteditcustomstand(""%{_player}%"" parsed as player,""leftleg"",""y"")",true)
+	setguiitem({_player},32,{@zcoorditem},1,{_leftleglang},{_zlang},"starteditcustomstand(""%{_player}%"" parsed as player,""leftleg"",""z"")",true)
+	#
+	# > Boots
+	setguiitem({_player},27,leather boots,1,"%{_feetlang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""foot"")",false)
+	if {_target}.getBoots() is air:
+		setguiitem({_player},28,{@noitemselecteditem},1,"%{_feetlang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""foot"")",false)
+	else:
+		set {_item} to {_target}.getBoots()
+		setguiitem({_player},28,{_item},1,"%{_feetlang}%",{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""foot"")",false)
+	#
+	# > Right arm
+	setguiitem({_player},36,stick,1,{_rightarmlang},{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""rightarm"")",false)
+	if {_target}'s tool is air:
+		setguiitem({_player},37,{@noitemselecteditem},1,{_rightarmlang},{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""rightarm"")",false)
+	else:
+		set {_item} to {_target}'s tool
+		setguiitem({_player},37,{_item},1,{_rightarmlang},{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""rightarm"")",false)
+	#
+	# > Right arm coordinate items
+	setguiitem({_player},39,{@xcoorditem},1,{_rightarmlang},{_xlang},"starteditcustomstand(""%{_player}%"" parsed as player,""rightarm"",""x"")",true)
+	setguiitem({_player},40,{@ycoorditem},1,{_rightarmlang},{_ylang},"starteditcustomstand(""%{_player}%"" parsed as player,""rightarm"",""y"")",true)
+	setguiitem({_player},41,{@zcoorditem},1,{_rightarmlang},{_zlang},"starteditcustomstand(""%{_player}%"" parsed as player,""rightarm"",""z"")",true)
+	#
+	# > Left arm
+	setguiitem({_player},45,stick,1,{_leftarmlang},{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""leftarm"")",false)
+	if {_target}'s offhand tool is air:
+		setguiitem({_player},46,{@noitemselecteditem},1,{_leftarmlang},{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""leftarm"")",false)
+	else:
+		set {_item} to {_target}'s offhand tool
+		setguiitem({_player},46,{_item},1,{_leftarmlang},{_placeslotlang},"changecustomstandslot(""%{_player}%"" parsed as player,event,""leftarm"")",false)
+	#
+	# > Left arm coordinate items
+	setguiitem({_player},48,{@xcoorditem},1,{_leftarmlang},{_xlang},"starteditcustomstand(""%{_player}%"" parsed as player,""leftarm"",""x"")",true)
+	setguiitem({_player},49,{@ycoorditem},1,{_leftarmlang},{_ylang},"starteditcustomstand(""%{_player}%"" parsed as player,""leftarm"",""y"")",true)
+	setguiitem({_player},50,{@zcoorditem},1,{_leftarmlang},{_zlang},"starteditcustomstand(""%{_player}%"" parsed as player,""leftarm"",""z"")",true)
+	#
+	# > Special options
+	setguiitem({_player},7,{@directionitem},1,{_changedirectionlang},{_togglearmslorelang},"starteditcustomstand(""%{_player}%"" parsed as player,""direction"",""direction"")",true)
+	#
+	# > Only show the clone item in the inventory menu if the player has the permission to do so.
+	if {_player} has permission "{@clonepermission}":
+		setguiitem({_player},8,{@cloneitem},1,{_copyarmorstandlang},{_copyarmorstandlorelang},"copycustomstand(""%{_player}%"" parsed as player)",true)
+	#
+	# > Change X Coordinate
+	setguiitem({_player},16,{@xcoorditem},1,{_xlang},"","starteditcustomstand(""%{_player}%"" parsed as player,""location"",""x"")",true)
+	#
+	# > Change Y Coordinate
+	setguiitem({_player},25,{@ycoorditem},1,{_ylang},"","starteditcustomstand(""%{_player}%"" parsed as player,""location"",""y"")",true)
+	#
+	# > Change Z Coordinate
+	setguiitem({_player},34,{@zcoorditem},1,{_zlang},"","starteditcustomstand(""%{_player}%"" parsed as player,""location"",""z"")",true)
+	#
+	# > Toggle size
+	setguiitem({_player},17,{@togglesizeitem},1,{_togglesizelang},{_togglesizelorelang},"togglecustomstanddata(""%{_player}%"" parsed as player,""size"")",true)
+	#
+	# > Toggle visibility
+	setguiitem({_player},26,{@togglevisibilityitem},1,{_togglevisibilitylang},{_togglevisibilitylorelang},"togglecustomstanddata(""%{_player}%"" parsed as player,""visible"")",true)
+	#
+	# > Toggle glow
+	setguiitem({_player},35,{@toggleglowitem},1,{_toggleglowlang},{_toggleglowlorelang},"togglecustomstanddata(""%{_player}%"" parsed as player,""glow"")",true)
+	#
+	# > Toggle baseplate
+	setguiitem({_player},44,{@togglebaseplateitem},1,{_togglebaseplatelang},{_togglebaseplatelorelang},"togglecustomstanddata(""%{_player}%"" parsed as player,""baseplate"")",true)
+	#
+	# > Toggle arms
+	setguiitem({_player},53,{@togglearmsitem},1,{_togglearmslang},{_togglearmslorelang},"togglecustomstanddata(""%{_player}%"" parsed as player,""arms"")",true)
+	#
+	# > Toggle custom name visibility
+	setguiitem({_player},43,{@togglenamevisibilityitem},1,{_togglenamelang},{_togglenamelorelang},"togglecustomstanddata(""%{_player}%"" parsed as player,""name"")",true)
+	#
+	# > Remove the armor stand
+	setguiitem({_player},52,{@removearmorstanditem},1,{_removearmorstandlang},{_removearmorstandlorelang},"removecustomstand(""%{_player}%"" parsed as player)",true)
+
+#
+# > Function - removecustomstand
+# > Parameters:
+# > <player>player
+# > Actions:
+# > Kills the armor stand the player wanted to remove. This should only
+# > be called if the right target is set in the metadata of the player.
+function removecustomstand(player:player):
+	#
+	# > Give the player a copy of the custom armor stand and then kill it.
+	copycustomstand({_player})
+	set {_target} to metadata value "customarmorstand-target" of {_player}
+	kill {_target}
+
+#
+# > Function - copycustomstand
+# > Parameters:
+# > <player>player
+# > Actions:
+# > Creates a copy item which can be used to copy the armor stand.
+function copycustomstand(player:player):
+	#
+	# > Get the translation for the tool as local variable.
+	set {_uuid} to uuid of {_player}
+	set {_lang} to {SK::lang::%{_uuid}%}
+	if {SB::lang::cs::copytoolname::%{_lang}%} is not set:
+		set {_copytoolnamelang} to "{@copytoolname}"
+		set {_copytoollorelang} to "{@copytoollore}"
+	else:
+		set {_copytoolnamelang} to {SB::lang::cs::copytoolname::%{_lang}%}
+		set {_copytoollorelang} to {SB::lang::cs::copytoollore::%{_lang}%}
+	#
+	# > Get the target from the metadata of the player.
+	set {_target} to metadata value "customarmorstand-target" of {_player}
+	#
+	# > Create a random uuid for the copied armor stand.
+	set {_newuuid} to UUID.randomUUID()
+	#
+	# > Create a new item which is the predefined copy tool from the options,
+	# > whicch is going to be named as written in the predefined language.
+	set {_item} to 1 of {@copytool} named "%{_copytoolnamelang}%"
+	#
+	# > Set the lore of the tool to the information for the player. Also
+	# > uses the predefined text from the language files or fallback translation.
+	set {_copytoollorelang::*} to {_copytoollorelang} split at "\n"
+	loop size of {_copytoollorelang::*} times:
+		set line loop-number of {_item}'s lore to {_copytoollorelang::%loop-number%}
+	#
+	# > Sets the armor stand object to the metadata value named
+	# > after the new random uuid to the player.
+	set metadata "%{_newuuid}%" of {_player} to {_target}	
+	#
+	# > Save the random uuid to the nbt tag "customstand" to get the
+	# > armor stand object later back, if the player uses the tool.
+	set {_item} to setnbtvalue({_item},"customstand","%{_newuuid}%")
+	#
+	# > Give the player one of the copy tool.
+	give 1 of {_item} to {_player}
+
+#
+# > Function - changecustomstandslot
+# > Parameters:
+# > <player>the player who wants to change the slot
+# > <event>the click event to get the cursor
+# > <text>the destination of which slot should be changed
+# > Actions:
+# > Changes the defined slot of the armor stand to the one the player
+# > has in the cursor.
+function changecustomstandslot(player:player,event:event,destination:text):
+	#
+	# > Get the target to change the slot. This is a custom armor stand.
+	set {_target} to metadata value "customarmorstand-target" of {_player}
+	
+	#
+	# > Gegt the item in the curser of the player.
+	set {_item} to {_event}.getCursor()
+	#
+	# > If the amount of the item in the curser is 1, set the curser item to air.
+	if {_item}.getAmount() is 1:
+		{_player}.setItemOnCursor(null)
+	#
+	# > If the amount of the curser is bigger than 0, remove 1 from the ItemStack.
+	else:
+		{_item}.setAmount({_item}.getAmount()-1)
+	#
+	# > Set the item to a valid ItemStack amount to place it within a slot
+	# > of a armor stand.
+	set {_placeitem} to 1 of {_item}
+	#
+	# > Depending of the destination, set the slots. Also call the
+	# > getarmorstanditemback function to give the player the item
+	# > back with a fluent transition.
+	if {_destination} is "head":
+		getarmorstanditemback({_player},{_event}.getCursor(),{_target}.getHelmet())
+		{_target}.setHelmet({_placeitem})
+	if {_destination} is "body":
+		getarmorstanditemback({_player},{_event}.getCursor(),{_target}.getChestplate())
+		{_target}.setChestplate({_placeitem})
+	if {_destination} is "leg":
+		getarmorstanditemback({_player},{_event}.getCursor(),{_target}.getLeggings())
+		{_target}.setLeggings({_placeitem})
+	if {_destination} is "foot":
+		getarmorstanditemback({_player},{_event}.getCursor(),{_target}.getBoots())
+		{_target}.setBoots({_placeitem})
+	if {_destination} is "rightarm":
+		#
+		# > We have to set the tool to a variable before using it within a function,
+		# > otherwise this would result in an error. This may change in the future.
+		set {_tool} to {_target}'s tool
+		getarmorstanditemback({_player},{_event}.getCursor(),{_tool})
+		set {_target}'s tool to {_placeitem}
+	if {_destination} is "leftarm":
+		#
+		# > We have to set the tool to a variable before using it within a function,
+		# > otherwise this would result in an error. This may change in the future.
+		set {_tool} to {_target}'s offhand tool
+		getarmorstanditemback({_player},{_event}.getCursor(),{_tool})
+		set {_target}'s offhand tool to {_placeitem}
+	#
+	# > Update the inventory of the player and reopen the updated version of the menu.
+	{_player}.updateInventory()
+	opencustomstandmenu({_player})
+
+#
+# > Functions - getarmorstanditemback
+# > Parameters:
+# > <player>the player who should get the item back
+# > <item>the current cursor item of the player
+# > <item>the item which should be given to the player
+# > Actions:
+# > Give the player the item back.
+function getarmorstanditemback(player:player,cursor:item,item:item):
+	#
+	# > If the cursor is empty (air), set the cursor directly to the item.
+	if {_cursor} is air:
+		{_player}.setItemOnCursor({_item})
+	#
+	# > If the cursor isn't empty, give it into the inventory, if there
+	# > is enough space.
+	else:
+		if {_player}'s inventory has space for {_item}:
+			give {_item} to {_player}'s inventory
+		#
+		# > If there is not enough space, drop the item at the player.
+		else:
+			drop {_item} at {_player}'s location
+
+#
+# > Function - starteditcustomstand
+# > Parameters:
+# > <player>the player who edits the custom armor stand
+# > <text>the part which should be edited by the player
+# > <text>the angle which is edited by the player
+# > Actions:
+# > Changes the armor stand by checking the current hotbar slot of the player.
+# > By scrolling with the mouse, the player can change the angles of the
+# > armor stand with ease. Calls the customstandchangepose function to
+# > change the armor stand.
+function starteditcustomstand(player:player,part:text,angle:text):
+	#
+	# > Get the armor stand which should be changed.
+	set {_target} to metadata value "customarmorstand-target" of {_player}
+	#
+	# > Set the current part and angle as metadata.
+	set metadata "customarmorstand-part" of {_player} to {_part}
+	set metadata "customarmorstand-angle" of {_player} to {_angle}
+	#
+	# > Set the current timestamp as metadata. This is needed because the while
+	# > loop has to detect if the time has changed, which would mean that the player
+	# > started another edit process.
+	set {_now} to now
+	set metadata "customarmorstand-now" of {_player} to {_now}
+	#
+	# > While loop this as long as {_ok} is true.
+	set {_ok} to true
+	while {_ok} is true:
+		#
+		# > Wait a tick between every loop.
+		wait 1 tick
+		#
+		# > If the previously saved timestamp has changed, stop here.
+		if metadata "customarmorstand-now" of {_player} is not {_now}:
+			stop
+		#
+		# > To prevent the while loop from endlessly looping,
+		# > check if the player is no longer looking at the
+		# > armor stand which should be changed, after 50 times
+		# > not looking at the armor stand, this loop is stopped.
+		if {_target} is not {_player}'s target:
+			add 1 to {_notok}
+			if {_notok} > 50:
+				set {_ok} to false
+				actionbar({_player},"")
+				stop
+			actionbar({_player},"Look at the armorstand to edit it [%{_notok}%/50]")
+		#
+		# > If the player looks at the armor stand and has looked away
+		# > for some time, delete the "not looking to the armor stand" counter.
+		else:
+			if {_notok} is set:
+				actionbar({_player},"")
+			delete {_notok}
+		#
+		# > Change the armor stand depending on the previous slot of the
+		# > player. The player can change the armor stand by scrolling through
+		# > the hotbar.
+		set {_changed} to false
+		set {_slot} to current hotbar slot id of {_player}
+		if {_lastslot} is not set:
+			set {_lastslot} to {_slot}
+		#
+		# > If the last slot was 8 (the last one on the right side) and the
+		# > current one is 0, which is the first one on the left side, the
+		# > player wanted to increase value.
+		if {_lastslot} is 8:
+			if {_slot} is 0:
+				if {_changed} is false:
+					set {_changed} to true
+					set {_lastslot} to {_slot}
+					customstandchangepose("add",{_target},{_player})
+		#
+		# > If the last slow was 0, (first one on the left side) and the
+		# > current one is slot 8, (the last one on the right side), the player
+		# > wanted to reduce the value.
+		if {_lastslot} is 0:
+			if {_slot} is 8:
+				if {_changed} is false:
+					set {_changed} to true
+					set {_lastslot} to {_slot}
+					customstandchangepose("remove",{_target},{_player})
+		#
+		# > If the slot is bigger than the last slot, the player wants
+		# > to increase the value.
+		if {_lastslot} < {_slot}:
+			if {_changed} is false:
+				set {_changed} to true
+				set {_lastslot} to {_slot}
+				customstandchangepose("add",{_target},{_player})
+		#
+		# > If the slot is smaller than the last slot, the player wants
+		# > to reduce the value.
+		if {_lastslot} > {_slot}:
+			if {_changed} is false:
+				set {_changed} to true
+				set {_lastslot} to {_slot}
+				customstandchangepose("remove",{_target},{_player})
+
+#
+# > Function - togglecustomstanddata
+# > Parameters:
+# > <player>the player who edits the custom armor stand
+# > <text>action - what should be toggled
+# > Actions:
+# > Toggles booleans for different settings.
+function togglecustomstanddata(player:player,action:text):
+	#
+	# > Get the armor stand which should be edited.
+	set {_target} to metadata value "customarmorstand-target" of {_player}
+	#
+	# > Toggle the size.
+	if {_action} is "size":
+		if {_target}.isSmall():
+			{_target}.setSmall(false)
+		else:
+			{_target}.setSmall(true)
+	#
+	# > Toggle the visibility.
+	else if {_action} is "visible":
+		if {_target}.isVisible():
+			{_target}.setVisible(false)
+		else:
+			{_target}.setVisible(true)
+	#
+	# > Toggle the glowing state.
+	else if {_action} is "glow":
+		if {_target}.isGlowing():
+			{_target}.setGlowing(false)
+		else:
+			{_target}.setGlowing(true)
+	#
+	# > Toggle the baseplate.
+	else if {_action} is "baseplate":
+		if {_target}.hasBasePlate():
+			{_target}.setBasePlate(false)
+		else:
+			{_target}.setBasePlate(true)
+	#
+	# > Toggle the arms.
+	else if {_action} is "arms":
+		if {_target}.hasArms():
+			{_target}.setArms(false)
+		else:
+			{_target}.setArms(true)
+	#
+	# > Toggle the visibility of the name.
+	else if {_action} is "name":
+		if {_target}.isCustomNameVisible():
+			{_target}.setCustomNameVisible(false)
+		else:
+			{_target}.setCustomNameVisible(true)
+
+#
+# > Function - customstandchangepose
+# > Parameters:
+# > <text>the action, either "add" or "remove"
+# > <entity>the target entity which should be changed
+# > <player>the player who wants to change the custom armor stand
+# > Actions:
+# > Changes the armor stand depending on what the player decided within the
+# > custom armor stand menu.
+function customstandchangepose(action:text,target:entity,player:player):
+	#
+	# > Get which part and angle the player wants to change.
+	set {_part} to metadata value "customarmorstand-part" of {_player}
+	set {_anglesetting} to metadata value "customarmorstand-angle" of {_player}
+	#
+	# > If the player is sneaking, decrese the value which is changed,
+	# > to allow the player making precise movements.
+	if {_player} is sneaking:
+		set {_change} to 0.005
+		#
+		# > If the player wants to change the direction, be less percise.
+		if {_part} is "direction":
+			set {_change} to 0.5
+	#
+	# > If the player is not sneaking, be less percise.
+	else:
+		set {_change} to 0.1
+		if {_part} is "direction":
+			set {_change} to 5
+	#
+	# > Depending on which part should be edited, get the angle, location or
+	# > what is needed to change the pose.
+	if {_part} is "head":
+		set {_angle} to {_target}.getHeadPose()
+	else if {_part} is "body":
+		set {_angle} to {_target}.getBodyPose()
+	else if {_part} is "rightarm":
+		set {_angle} to {_target}.getRightArmPose()
+	else if {_part} is "leftarm":
+		set {_angle} to {_target}.getLeftArmPose()
+	else if {_part} is "rightleg":
+		set {_angle} to {_target}.getRightLegPose()
+	else if {_part} is "leftleg":
+		set {_angle} to {_target}.getLeftLegPose()
+	else if {_part} is "direction":
+		set {_loc} to location of {_target}
+	else if {_part} is "location":
+		set {_loc} to location of {_target}
+	#
+	# > If the change should be added, add it depending on what should be changed.
+	# > Possible is any EulerAnlge part, location and direction.
+	if {_action} is "add":
+		if {_anglesetting} is "x":
+			set {_angle} to {_angle}.add({_change},0,0)
+			if {_part} is "location":
+				add {_change} to x-coord of {_loc}
+		else if {_anglesetting} is "y":
+			set {_angle} to {_angle}.add(0,{_change},0)
+			if {_part} is "location":
+				add {_change} to y-coord of {_loc}
+		else if {_anglesetting} is "z":
+			set {_angle} to {_angle}.add(0,0,{_change})
+			if {_part} is "location":
+				add {_change} to z-coord of {_loc}
+		else if {_anglesetting} is "direction":
+			add {_change} to {_loc}'s yaw
+	#
+	# > The same as above with the add action. Here are EulerAnlges, locations
+	# > and directions changed which get later assigned back to the armor stand.
+	if {_action} is "remove":
+		if {_anglesetting} is "x":
+			set {_angle} to {_angle}.subtract({_change},0,0)
+			if {_part} is "location":
+				remove {_change} from x-coord of {_loc}
+		else if {_anglesetting} is "y":
+			set {_angle} to {_angle}.subtract(0,{_change},0)
+			if {_part} is "location":
+				remove {_change} from y-coord of {_loc}
+		else if {_anglesetting} is "z":
+			set {_angle} to {_angle}.subtract(0,0,{_change})
+			if {_part} is "location":
+				remove {_change} from z-coord of {_loc}
+		else if {_anglesetting} is "direction":
+			remove {_change} from {_loc}'s yaw
+	#
+	# > Set the changed data back to the armor stand.
+	if {_part} is "head":
+		{_target}.setHeadPose({_angle})
+	else if {_part} is "body":
+		{_target}.setBodyPose({_angle})
+	else if {_part} is "rightarm":
+		{_target}.setRightArmPose({_angle})
+	else if {_part} is "leftarm":
+		{_target}.setLeftArmPose({_angle})
+	else if {_part} is "rightleg":
+		{_target}.setRightLegPose({_angle})
+	else if {_part} is "leftleg":
+		{_target}.setLeftLegPose({_angle})
+	else if {_part} is "direction" or "location":
+		teleport {_target} to {_loc}

--- a/SkyBlock/addons/customarmorstands.sk
+++ b/SkyBlock/addons/customarmorstands.sk
@@ -114,6 +114,7 @@ options:
 	togglenamelore: &7Toggle the name\n&7between visible and invisible.\n&7Customize the name\n&7with /renamestand <text>.
 	removearmorstand: &rRemove
 	removearmorstandlore: &7Remove this armor stand\n&7and get a copy of it\n&7to replace the armor stand.
+	lookatstand: Look at the armorstand to edit it [<number>/50]
 	#
 	# > Please note: You may want to change the function "checkarmorstandplacepermission" below to fit
 	# > it into your protections system. It should return true if the player is allowed to change the armor stand.
@@ -645,7 +646,14 @@ function starteditcustomstand(player:player,part:text,angle:text):
 				set {_ok} to false
 				actionbar({_player},"")
 				stop
-			actionbar({_player},"Look at the armorstand to edit it [%{_notok}%/50]")
+			set {_uuid} to uuid of {_player}
+			set {_lang} to {SK::lang::%{_uuid}%}
+			if {SB::lang::cs::lookatstand::%{_lang}%} is not set:
+				set {_msg} to "{@lookatstand}"
+			else:
+				set {_msg} to {SB::lang::cs::lookatstand::%{_lang}%}
+			replace all "<number>" with "%{_notok}%" in {_msg}
+			actionbar({_player},{_msg})
 		#
 		# > If the player looks at the armor stand and has looked away
 		# > for some time, delete the "not looking to the armor stand" counter.

--- a/SkyBlock/addons/customarmorstands.sk
+++ b/SkyBlock/addons/customarmorstands.sk
@@ -150,31 +150,31 @@ on rightclick holding {@copytool}:
 		if player's gamemode is not creative:
 			remove 1 of player's tool from player's inventory
 		spawn 1 armor stand at {_loc}
-		set {_robo} to last spawned entity
-		{_robo}.setGravity(false)
-		{_robo}.setBasePlate({_target}.hasBasePlate())
-		{_robo}.setCanPickupItems(false)
-		{_robo}.setCustomName({_target}.getCustomName())
-		{_robo}.setCustomNameVisible({_target}.isCustomNameVisible())
-		{_robo}.setVisible({_target}.isVisible())
-		{_robo}.setSmall({_target}.isSmall())
-		{_robo}.setArms({_target}.hasArms())
-		{_robo}.setInvulnerable(true)
-		{_robo}.setGlowing({_target}.isGlowing())
+		set {_stand} to last spawned entity
+		{_stand}.setGravity(false)
+		{_stand}.setBasePlate({_target}.hasBasePlate())
+		{_stand}.setCanPickupItems(false)
+		{_stand}.setCustomName({_target}.getCustomName())
+		{_stand}.setCustomNameVisible({_target}.isCustomNameVisible())
+		{_stand}.setVisible({_target}.isVisible())
+		{_stand}.setSmall({_target}.isSmall())
+		{_stand}.setArms({_target}.hasArms())
+		{_stand}.setInvulnerable(true)
+		{_stand}.setGlowing({_target}.isGlowing())
 		
-		{_robo}.setHelmet({_target}.getHelmet())
-		{_robo}.setChestplate({_target}.getChestplate())
-		{_robo}.setLeggings({_target}.getLeggings())
-		{_robo}.setBoots({_target}.getBoots())
-		set {_robo}'s offhand tool to {_target}'s offhand tool
-		set {_robo}'s tool to {_target}'s tool
+		{_stand}.setHelmet({_target}.getHelmet())
+		{_stand}.setChestplate({_target}.getChestplate())
+		{_stand}.setLeggings({_target}.getLeggings())
+		{_stand}.setBoots({_target}.getBoots())
+		set {_stand}'s offhand tool to {_target}'s offhand tool
+		set {_stand}'s tool to {_target}'s tool
 		
-		{_robo}.setHeadPose({_target}.getHeadPose())
-		{_robo}.setBodyPose({_target}.getBodyPose())
-		{_robo}.setRightArmPose({_target}.getRightArmPose())
-		{_robo}.setLeftArmPose({_target}.getLeftArmPose())
-		{_robo}.setRightLegPose({_target}.getRightLegPose())
-		{_robo}.setLeftLegPose({_target}.getLeftLegPose())
+		{_stand}.setHeadPose({_target}.getHeadPose())
+		{_stand}.setBodyPose({_target}.getBodyPose())
+		{_stand}.setRightArmPose({_target}.getRightArmPose())
+		{_stand}.setLeftArmPose({_target}.getLeftArmPose())
+		{_stand}.setRightLegPose({_target}.getRightLegPose())
+		{_stand}.setLeftLegPose({_target}.getLeftLegPose())
 
 #
 # > On rightclick holding an armor stand

--- a/SkyBlock/addons/gui.sk
+++ b/SkyBlock/addons/gui.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# GUI.SK v0.0.5
+# GUI.SK v0.0.6
 # ==============
 # Create GUI menus fast and secure with all available inventory types.
 # ==============
@@ -248,8 +248,7 @@ function setguiitem(player:player,slot:number,item:item,amount:integer,name:text
   {_ItemMeta}.setLore({_itemlore})
   {_ItemStack}.setItemMeta({_ItemMeta})
   set slot {_slot} of {SK::GUI::inv::%{_player}%} to {_amount} of {_ItemStack}
-  if {_exec} != "":
-    set {SK::GUI::items::%{_player}%::%{_slot}%} to {_exec}
+  set {SK::GUI::items::%{_player}%::%{_slot}%} to {_exec}
   if {_close} is true:
     set {SK::GUI::itemsclose::%{_player}%::%{_slot}%} to true
 
@@ -263,10 +262,12 @@ function setguiitem(player:player,slot:number,item:item,amount:integer,name:text
 # > If it was defined to close the players inventory, it is going to happen, if {SK::GUI::itemsclose::%{_player}%::%{_slot}%} is true.
 on InventoryClickEvent:
   set {_player} to event.getWhoClicked()
+
   if {SK::GUI::inv::%{_player}%} is set:
     if size of {SK::GUI::items::%{_player}%::*} is not 0:
-      cancel event
       set {_slot} to event.getRawSlot()
+      if {SK::GUI::items::%{_player}%::%{_slot}%} is set:
+        cancel event
       #
       # > If guis should do something special on shiftclick, they can add another function with ||, which gets executed on shift click.
       set {_exec::*} to {SK::GUI::items::%{_player}%::%{_slot}%} split at "||"

--- a/SkyBlock/addons/gui.sk
+++ b/SkyBlock/addons/gui.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# GUI.SK v0.0.6
+# GUI.SK v0.0.7
 # ==============
 # Create GUI menus fast and secure with all available inventory types.
 # ==============
@@ -251,6 +251,15 @@ function setguiitem(player:player,slot:number,item:item,amount:integer,name:text
   set {SK::GUI::items::%{_player}%::%{_slot}%} to {_exec}
   if {_close} is true:
     set {SK::GUI::itemsclose::%{_player}%::%{_slot}%} to true
+#
+# > Function: protectslot - Protects a slot within the gui
+# > Parameters:
+# > <player>player
+# > <number> slot
+# > Actions:
+# > Set a variable for the slot to prevent modification of it.
+function protectslot(player:player,slot:number):
+  set {SK::GUI::items::%{_player}%::%{_slot}%} to " "
 
 # > Event - InventoryClickEvent
 # > This event gets triggered if a player clicks in his inventory.

--- a/SkyBlock/addons/lootbox.sk
+++ b/SkyBlock/addons/lootbox.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# lootbox.sk v0.0.3
+# lootbox.sk v0.0.4
 # ==============
 # Create custom lootboxes with three different tiers and animations.
 # ==============
@@ -295,6 +295,7 @@ function openlootboxmenu(p:player):
   # > Empty slots are shown as black stained glass.
   loop 27 times:
     set slot loop-number - 1 of {_p}'s current inventory to black stained glass pane named " "
+    protectslot({_p},loop-number - 1)
   #
   # > The uuid only works if we set it first as a local variable.
   set {_uuid} to uuid of {_p}
@@ -364,10 +365,9 @@ function openlootbox(p:player,tier:integer):
   playsound({_p},location of {_p},"{@openlootboxsound}","master",1,1)
   #
   # > Create a fancy menu, which contains blacck glass panes.
-  set {_i} to 0
   loop 27 times:
-    set slot {_i} of {_p}'s current inventory to {@secondarymenuitem} named " "
-    add 1 to {_i}
+    set slot loop-number - 1 of {_p}'s current inventory to {@secondarymenuitem} named " "
+    protectslot({_p},loop-number - 1)
   #
   # > Set the menu item for the lootbox into it, which starts the lootbox opening, if clicked.
   set {_uuid} to uuid of {_p}

--- a/SkyBlock/addons/oregenerator.sk
+++ b/SkyBlock/addons/oregenerator.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# oregenerator.sk v0.0.5
+# oregenerator.sk v0.0.6
 # ==============
 # Allows users to build cobblestone generators which generate ores.
 # ==============
@@ -144,14 +144,38 @@ on load:
   set {SB::config::oregenmaxlevelbonus} to 500
 
 #
-# > Event: on block growth
+# > Import the BlockFromToEvent event from Bukkit to detect Cobblestone form.
+import:
+  org.bukkit.event.block.BlockFromToEvent
+#
+# > Event: BlockFromToEvent
 # > Triggered once a block is created
 # > Actions:
 # > If the event-block is cobblestone or stone, call the oregeneratorplace
 # > function with the location of the event block.
-on block growth:
-  if event-block is cobblestone or stone:
-    oregeneratorplace(location of event-block)
+on BlockFromToEvent:
+  set {_type} to event.getBlock()
+  if {_type} is water or stationary water or lava or stationary lava:
+    if event.getToBlock() is air:
+      if metadata value "generator" of event.getToBlock() is true:
+        #
+        # > Only generate a cobblestone and cancel if there is a valid
+        # > cobblestone generator there. (Lava + Water)
+        loop all blocks in radius 1 around event.getToBlock():
+          if {_type} is water or stationary water:
+            if loop-block is lava or stationary lava:
+              cancel event
+              oregeneratorplace(event.getToBlock().getLocation())
+              stop
+          if {_type} is lava or stationary lava:
+            if loop-block is water or stationary water:
+              cancel event
+              oregeneratorplace(event.getToBlock().getLocation())
+              stop
+      wait 1 tick
+      if event.getToBlock() is cobblestone or stone:
+        set metadata value "generator" of event.getToBlock() to true
+        oregeneratorplace(event.getToBlock().getLocation())
 
 #
 # > Function - oregeneratorplace:

--- a/SkyBlock/addons/robots.sk
+++ b/SkyBlock/addons/robots.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# robots.sk v0.0.2
+# robots.sk v0.0.3
 # ==============
 # Give your players robots which can help them farm stuff.
 # ==============
@@ -40,7 +40,7 @@ import:
   org.bukkit.Material
   org.bukkit.inventory.ItemStack
   org.bukkit.util.EulerAngle
-  org.bukkit.event.player.PlayerArmorStandManipulateEvent 
+  org.bukkit.event.player.PlayerInteractAtEntityEvent
   org.bukkit.Particle
   org.bukkit.Effect
   org.bukkit.Color
@@ -1393,12 +1393,12 @@ on unload:
     disablerobot(loop-value)
 
 #
-# > Event - PlayerArmorStandManipulateEvent
+# > Event - PlayerInteractAtEntityEvent
 # > Actions:
-# > If the player wants to manipulate the armor stand (taking items out of it),
+# > If the player wants to click the armor stand,
 # > cancel the event and open the robot main menu. This event happens always once
 # > a player clicks on the armor stand.
-on PlayerArmorStandManipulateEvent:
+on PlayerInteractAtEntityEvent:
   set {_value} to getnbtvalue(helmet of event.getRightClicked(),"robot")
   if {_value} is "robotsk":
     cancel event

--- a/SkyBlock/addons/robots.sk
+++ b/SkyBlock/addons/robots.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# robots.sk v0.0.3
+# robots.sk v0.0.4
 # ==============
 # Give your players robots which can help them farm stuff.
 # ==============
@@ -725,7 +725,7 @@ function openrobotskmenu(robot:entity,player:player):
   #
   # > Fill the Inventory with empty glass panes.
   loop 36 times:
-    set slot loop-number - 1 of {_player}'s current inventory to black stained glass pane named " "
+    setguiitem({_player},loop-number - 1,black stained glass pane,1," ",""," ",false)
   #
   # > Save the current robot which has been opened to a variable
   # > to get the robot later again, if needed.

--- a/SkyBlock/lang/de.sk
+++ b/SkyBlock/lang/de.sk
@@ -437,7 +437,8 @@ on script load:
   set {SB::lang::cs::removearmorstandlore::%{_lang}%} to "&7Entferne diesen\n&7Rüstungsständer und\n&7erhalte eine Kopie\n&7davon zum platzieren."
   set {SB::lang::cs::copytoolname::%{_lang}%} to "&rKopierstab"
   set {SB::lang::cs::copytoollore::%{_lang}%} to "&7Dieses Werkzeug kopiert\n&7den Rüstungsständer temporär,\n&7verwende es nicht,\n&7zum lagern."
-  
+  set {SB::lang::cs::lookatstand::%{_lang}%} to "Schaue den Rüstungsständer an, um ihn zu bearbeiten. [<number>/50]"
+
   #
   # > Robots
   #

--- a/SkyBlock/lang/de.sk
+++ b/SkyBlock/lang/de.sk
@@ -221,6 +221,7 @@ on script load:
   set {SB::lang::maingui::guihublore::%{_lang}%} to "%{_s1}%Teleportiert dich zur Lobby."
   set {SB::lang::maingui::guilanglore::%{_lang}%} to "%{_s1}%Ändere deine Sprache."
   set {SB::lang::maingui::guiflaglore::%{_lang}%} to "%{_s1}%Ändere die Flags deiner Insel."
+  set {SB::lang::maingui::islandupgradelore::%{_lang}%} to "%{_s1}%Erweitere deine Insel."
   set {SB::lang::guibacktopreviousmenulore::%{_lang}%} to "%{_s1}%Bringt dich zurück\n%{_s1}%zum übergeordneten Menü."
 
   #

--- a/SkyBlock/lang/de.sk
+++ b/SkyBlock/lang/de.sk
@@ -403,6 +403,42 @@ on script load:
   set {SB::lang::parcour::parcouritemstart::%{_lang}%} to "&r%{_p2}%Parkour - Start"
 
   #
+  # > Custom Stands addon
+  set {SB::lang::cs::guiheader::%{_lang}%} to "&lRüstungsständer anpassen"
+  set {SB::lang::cs::head::%{_lang}%} to "&rKopf"
+  set {SB::lang::cs::body::%{_lang}%} to "&rOberkörper"
+  set {SB::lang::cs::legs::%{_lang}%} to "&rBeine"
+  set {SB::lang::cs::feet::%{_lang}%} to "&rFüße"
+  set {SB::lang::cs::rightleg::%{_lang}%} to "&rRechtes Bein"
+  set {SB::lang::cs::leftleg::%{_lang}%} to "&rLinkes Bein"
+  set {SB::lang::cs::rightarm::%{_lang}%} to "&rRechter Arm"
+  set {SB::lang::cs::leftarm::%{_lang}%} to "&rLinker Arm"
+  set {SB::lang::cs::xcoord::%{_lang}%} to "X Koordinate"
+  set {SB::lang::cs::ycoord::%{_lang}%} to "Y Koordinate"
+  set {SB::lang::cs::zcoord::%{_lang}%} to "Z Koordinate"
+  set {SB::lang::cs::placeitemslot::%{_lang}%} to "&7Platziere das Item hier,\n&7welches du für diesen\n&7Slot haben möchtest."
+  set {SB::lang::cs::togglesize::%{_lang}%} to "&rGröße"
+  set {SB::lang::cs::togglesizelore::%{_lang}%} to "&7Schalte die Größe\n&7zwischen klein und groß um."
+  set {SB::lang::cs::togglevisibility::%{_lang}%} to "&rSichtbarkeit"
+  set {SB::lang::cs::togglevisibilitylore::%{_lang}%} to "&7Schalte die Sichtbarkeit\n&7des Rüstungsständers um."
+  set {SB::lang::cs::toggleglow::%{_lang}%} to "&rLeuchten"
+  set {SB::lang::cs::toggleglowlore::%{_lang}%} to "&7Schalte das Leuchten\n&7des Rüstungsständers um."
+  set {SB::lang::cs::togglebaseplate::%{_lang}%} to "&rBasisplatte"
+  set {SB::lang::cs::togglebaseplatelore::%{_lang}%} to "&7Schalte die Basisplatte\n&7des Rüstungsständers um."
+  set {SB::lang::cs::togglearms::%{_lang}%} to "&rArme"
+  set {SB::lang::cs::togglearmslore::%{_lang}%} to "&7Schalte die Arme\n&7des Rüstungsständers um."
+  set {SB::lang::cs::changedirection::%{_lang}%} to "&rRichtung"
+  set {SB::lang::cs::changedirectionlore::%{_lang}%} to "&7Stelle die Richtung\n&7des Rüstungsständers um."
+  set {SB::lang::cs::copyarmorstand::%{_lang}%} to "&rKopieren"
+  set {SB::lang::cs::copyarmorstandlore::%{_lang}%} to "&7Kopiere diesen\n&7Rüstungsständer."
+  set {SB::lang::cs::togglename::%{_lang}%} to "&rName"
+  set {SB::lang::cs::togglenamelore::%{_lang}%} to "&7Stelle den Namen des\n&7Rüstungsständers zwischen\n&7sichtbar und unsichtbar um.\n&7Ändere den Namen\n&7mit /renamestand <text>."
+  set {SB::lang::cs::removearmorstand::%{_lang}%} to "&rEntfernen"
+  set {SB::lang::cs::removearmorstandlore::%{_lang}%} to "&7Entferne diesen\n&7Rüstungsständer und\n&7erhalte eine Kopie\n&7davon zum platzieren."
+  set {SB::lang::cs::copytoolname::%{_lang}%} to "&rKopierstab"
+  set {SB::lang::cs::copytoollore::%{_lang}%} to "&7Dieses Werkzeug kopiert\n&7den Rüstungsständer temporär,\n&7verwende es nicht,\n&7zum lagern."
+  
+  #
   # > Robots
   #
   # > Robot jobs


### PR DESCRIPTION
Close https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/143 once merged.

Aims to create an easy to use tool to edit armor stands. Also edit the EulerAngle not using some weird mechanics or chat but by scrolling the mouse wheel.

- [x] Copy tool
- [x] Multilanguage (add translation to de.sk)
- [x] Fallback translation
- [x] Handle armor and tool items
- [x] Set coordinates of all EulerAngle parts of the armor stand
- [x] Edit direction of the armor stand
- [x] Edit coordinates of the armor stand
- [x] A tool to copy the armor stand
- [x] Add easy to edit permission function and add SKYBLOCK.SK support
- [x] Prevent changes on robots.sk addon armor stands
- [x] Make settings toggleable
- - [x] Toggle size
- - [x] Toggle visibility
- - [x] Toggle name visibility
- - [x] Toggle glow effect
- - [x] Toggle baseplate
- - [x] Toggle arms
- [x] All menu background items have been protected through the gui.sk function
- [x] Loading without errors
- [x] Tested
- [x] Fully working - no bugs detected

