### PR TITLE
/island top is now opened in a book

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Functions/islandtoplist.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/islandtoplist.sk
@@ -5,12 +5,25 @@
 # islandtoplist.sk is part of the SKYBLOCK.SK functions.
 # ==============
 
+import:
+	net.md_5.bungee.api.chat.TextComponent
+	net.md_5.bungee.api.chat.BaseComponent
+	net.md_5.bungee.api.chat.ComponentBuilder
+	net.md_5.bungee.api.chat.ClickEvent
+	net.md_5.bungee.api.chat.HoverEvent
+	net.md_5.bungee.api.chat.HoverEvent$Action as HoverEventAction
+	net.md_5.bungee.api.chat.ClickEvent$Action as ClickEventAction
+
 # > Function - islandtoplist:
 # > Arguments:
 # > <player>player, <text>pageint
 # > Actions:
 # > The islandtoplist sends a toplist into the chat of the player.
-function islandtoplist(p:player,pageint:text):
+function islandtoplist(p:player,pageint:text,gui:boolean=false):
+  #
+  # > Wait a short time to prevent client side bugs
+  if {_gui} is true:
+    wait 2 ticks
   #
   # > Save some variables to local variables.
   set {_pageint} to "%{_pageint}%" parsed as integer
@@ -84,15 +97,23 @@ function islandtoplist(p:player,pageint:text):
   if {_top::%{_pageint}%::*} is not set:
     set {_msg} to {SB::lang::pagenotfound::%{_lang}%}
     replace all "<pages>" with "%{_page}%" in {_msg}
-    message "%{_prefix}% %{_msg}%" to {_p}
     stop
-  message "%{SB::config::spacer}%" to {_p}
   #
-  # > Get the translation of the header and replace placeholders, then send it to the player.
-  set {_msg} to {SB::lang::istopheader::%{_lang}%}
-  replace all "<currentpage>" with "%{_pageint}%" in {_msg}
-  replace all "<allpages>" with "%{_page}%" in {_msg}
-  message "%{_prefix}% %{_msg}%" to {_p}
+  # > Create a new book which is going to be used.
+  set {_item} to written book
+  set {_bookmeta} to {_item}.getItemMeta()
+  {_bookmeta}.setTitle("test")
+  {_bookmeta}.setAuthor("Immanuel94")
+  #
+  # > Use the ComponentBuilder to create a text with hover and click events.
+  set {_toplistbook} to ""
+  set {_book} to new ComponentBuilder({_toplistbook})
+  #
+  # > The header line of the page.
+  set {_line} to {SB::lang::topheader::%{_lang}%}
+  replace all "<start>" with "%{_pageint}%" in {_line}
+  replace all "<end>" with "%{_page}%" in {_line}
+  {_book}.append("%{_line}%%nl%%nl%")
   #
   # > Loop through the toplist site, the player has requested.
   loop {_top::%{_pageint}%::*}:
@@ -109,17 +130,118 @@ function islandtoplist(p:player,pageint:text):
     set {_lp} to "%{SB::island::%loop-value%::leader}%" parsed as offline player
     #
     # > Get translated toplist and replace all placeholders to send it to the player.
-    set {_msg} to {SB::lang::istoplist::%{_lang}%}
-    replace all "<rank>" with loop-index in {_msg}
-    replace all "<leader>" with "%{_lp}%" in {_msg}
-    replace all "<points>" with "%{_level::%loop-value%}%" in {_msg}
-    replace all "<members>" with "%{_member}%" in {_msg}
-    message "%{_prefix}% %{_msg}%" to {_p}
+    set {_rank} to {SB::lang::istoplist::%{_lang}%}
+    set {_length} to loop-index parsed as number
+    set {_length} to "%{_length}+9%"
+    #
+    # > Changes all ranks to the same length by adding a 0 in front
+    # > of lower numbers.
+    if length of loop-index < length of {_length}:
+      replace all "<rank>" with "0%loop-index%" in {_rank}
+    else:
+      replace all "<rank>" with loop-index in {_rank}
+    #
+    # > Replace the name placeholder with the rank holder.
+    replace all "<name>" with "%{_lp}%" in {_rank}
+    set {_msg} to new TextComponent("%{_rank}%%nl%")
+    set {_msg} to setclickcmdevent({_msg},"/island info %{_lp}%")
+    {_msg}.setClickEvent({_clickevent})
+    #
+    # > Prepare and set the on hover event text for the toplist.
+    set {_hovertext} to {SB::lang::toplistbookhover::%{_lang}%}
+    replace all "<name>" with "%{_lp}%" in {_hovertext}
+    replace all "<rank>" with loop-index in {_hovertext}
+    replace all "<level>" with "%{_level::%loop-value%}%" in {_hovertext}
+    set {_msg} to sethovertextevent({_msg},{_hovertext})
+    {_book}.append({_msg})
+  #
+  # > Append a new line.
+  {_book}.append(new TextComponent(" %nl%"))
+  #
+  # > If this page isn't the first page, add a "back" button.
+  if {_pageint} != 1:
+    set {_msg} to new TextComponent("&l←&r")
+    set {_lore} to {SB::lang::store::pagebackwardlore::%{_lang}%}
+    set {_msg} to sethovertextevent({_msg},"%{SB::lang::store::pagebackward::%{_lang}%}%%nl%%{_lore}%")
+    set {_msg} to setclickcmdevent({_msg},"/island top %{_pageint} - 1%")
+    {_book}.append({_msg})
+  #
+  # > If the site is the first one, add the go back to previous menu command.
+  else:
+    set {_msg} to new TextComponent("&l←&r")
+    set {_lore} to {SB::lang::guibacktopreviousmenulore::%{_lang}%}
+    set {_msg} to sethovertextevent({_msg},"%{SB::lang::store::pagebackward::%{_lang}%}%%nl%%{_lore}%")
+    set {_msg} to setclickcmdevent({_msg},"/island")
+    {_book}.append({_msg})
+
+
+  #
+  # > If the current page is smaller than the maximum page size,
+  # > create the "go forward" text component.
+  if {_pageint} < {_page}:
+    #
+    # > Add some space between the "go backwards" text component.
+    set {_msg} to new TextComponent("                        ")
+    set {_msg} to overwritecomponentevents({_msg})
+    #
+    # > Add the actual "go forward" text component.
+    {_book}.append(new TextComponent({_msg}))
+    set {_msg} to new TextComponent("&l→&r")
+    set {_lore} to {SB::lang::store::pageforwardlore::%{_lang}%}
+    set {_msg} to sethovertextevent({_msg},"%{SB::lang::store::pageforward::%{_lang}%}%%nl%%{_lore}%")
+    set {_msg} to setclickcmdevent({_msg},"/island top %{_pageint} + 1%")
+    {_book}.append({_msg})
   #
   # > If the rank is set, replace the translation placeholder and send it to the player.
   if {_pRank} is set:
     set {_msg} to {SB::lang::istoprankinfo::%{_lang}%}
     replace all "<rank>" with "%{_pRank}%" in {_msg}
     replace all "<islands>" with "%{_size}%" in {_msg}
-    message "%{_prefix}% %{_msg}%" to {_p}
-  message "%{SB::config::spacer}%" to {_p}
+
+  #
+  # > Complete the BaseComponent by creating it and adding it to the sites list.
+  add {_book}.create() to {_sites::*}
+  #
+  # > Set the sites to the book and then open it to the player.
+  {_bookmeta}.spigot().setPages({_sites::*})
+  {_item}.setItemMeta({_bookmeta})
+  #
+  # > Get the item of the player to give it back after the book has been opened.
+  set {_tool} to {_p}'s tool
+  set {_p}'s tool to 1 of {_item}
+  openbook({_p})
+  set {_p}'s tool to {_tool}
+
+#
+# > Function - overwritecomponentevents
+# > Paremeters:
+# > <TextComponent>the text component which should get the events overwritten.
+# > Actions:
+# > Overwrites the events of the text components to make them normal again.
+function overwritecomponentevents(msg:object) :: object:
+  {_msg}.setClickEvent(new ClickEvent(ClickEventAction.RUN_COMMAND!,null))
+  {_msg}.setHoverEvent(new HoverEvent(HoverEventAction.SHOW_TEXT!,new ComponentBuilder(null).create()))
+  return {_msg}
+
+#
+# > Function - overwritecomponentevents
+# > Paremeters:
+# > <TextComponent>the text component which should get the events overwritten.
+# > Actions:
+# > Setts a on hover event on this text component and then returns it.
+# > HoverEvent: https://ci.md-5.net/job/BungeeCord/ws/chat/target/apidocs/net/md_5/bungee/api/chat/HoverEvent.Action.html
+function sethovertextevent(msg:object,text:object) :: object:
+  replace all "\n" with " %nl%" in {_text}
+  {_msg}.setHoverEvent(new HoverEvent(HoverEventAction.SHOW_TEXT!,new ComponentBuilder({_text}).create()))
+  return {_msg}
+
+#
+# > Function - setclickcmdevent
+# > Paremeters:
+# > <TextComponent>the text component which should get the events overwritten.
+# > Actions:
+# > Sets the click event to this text component and then returns it.
+# > ClickEvent: https://ci.md-5.net/job/BungeeCord/ws/chat/target/apidocs/net/md_5/bungee/api/chat/ClickEvent.Action.html
+function setclickcmdevent(msg:object,cmd:object) :: object:
+  {_msg}.setClickEvent(new ClickEvent(ClickEventAction.RUN_COMMAND!,{_cmd}))
+  return {_msg}

--- a/SkyBlock/SKYBLOCK.SK/Functions/islandtoplist.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/islandtoplist.sk
@@ -6,13 +6,13 @@
 # ==============
 
 import:
-	net.md_5.bungee.api.chat.TextComponent
-	net.md_5.bungee.api.chat.BaseComponent
-	net.md_5.bungee.api.chat.ComponentBuilder
-	net.md_5.bungee.api.chat.ClickEvent
-	net.md_5.bungee.api.chat.HoverEvent
-	net.md_5.bungee.api.chat.HoverEvent$Action as HoverEventAction
-	net.md_5.bungee.api.chat.ClickEvent$Action as ClickEventAction
+  net.md_5.bungee.api.chat.TextComponent
+  net.md_5.bungee.api.chat.BaseComponent
+  net.md_5.bungee.api.chat.ComponentBuilder
+  net.md_5.bungee.api.chat.ClickEvent
+  net.md_5.bungee.api.chat.HoverEvent
+  net.md_5.bungee.api.chat.HoverEvent$Action as HoverEventAction
+  net.md_5.bungee.api.chat.ClickEvent$Action as ClickEventAction
 
 # > Function - islandtoplist:
 # > Arguments:
@@ -102,7 +102,7 @@ function islandtoplist(p:player,pageint:text,gui:boolean=false):
   # > Create a new book which is going to be used.
   set {_item} to written book
   set {_bookmeta} to {_item}.getItemMeta()
-  {_bookmeta}.setTitle("test")
+  {_bookmeta}.setTitle("Toplist")
   {_bookmeta}.setAuthor("Immanuel94")
   #
   # > Use the ComponentBuilder to create a text with hover and click events.
@@ -159,22 +159,18 @@ function islandtoplist(p:player,pageint:text,gui:boolean=false):
   {_book}.append(new TextComponent(" %nl%"))
   #
   # > If this page isn't the first page, add a "back" button.
+  set {_msg} to new TextComponent("&l←&r")
   if {_pageint} != 1:
-    set {_msg} to new TextComponent("&l←&r")
     set {_lore} to {SB::lang::store::pagebackwardlore::%{_lang}%}
     set {_msg} to sethovertextevent({_msg},"%{SB::lang::store::pagebackward::%{_lang}%}%%nl%%{_lore}%")
     set {_msg} to setclickcmdevent({_msg},"/island top %{_pageint} - 1%")
-    {_book}.append({_msg})
   #
   # > If the site is the first one, add the go back to previous menu command.
   else:
-    set {_msg} to new TextComponent("&l←&r")
     set {_lore} to {SB::lang::guibacktopreviousmenulore::%{_lang}%}
     set {_msg} to sethovertextevent({_msg},"%{SB::lang::store::pagebackward::%{_lang}%}%%nl%%{_lore}%")
     set {_msg} to setclickcmdevent({_msg},"/island")
-    {_book}.append({_msg})
-
-
+  {_book}.append({_msg})
   #
   # > If the current page is smaller than the maximum page size,
   # > create the "go forward" text component.
@@ -191,13 +187,6 @@ function islandtoplist(p:player,pageint:text,gui:boolean=false):
     set {_msg} to sethovertextevent({_msg},"%{SB::lang::store::pageforward::%{_lang}%}%%nl%%{_lore}%")
     set {_msg} to setclickcmdevent({_msg},"/island top %{_pageint} + 1%")
     {_book}.append({_msg})
-  #
-  # > If the rank is set, replace the translation placeholder and send it to the player.
-  if {_pRank} is set:
-    set {_msg} to {SB::lang::istoprankinfo::%{_lang}%}
-    replace all "<rank>" with "%{_pRank}%" in {_msg}
-    replace all "<islands>" with "%{_size}%" in {_msg}
-
   #
   # > Complete the BaseComponent by creating it and adding it to the sites list.
   add {_book}.create() to {_sites::*}

--- a/SkyBlock/SKYBLOCK.SK/Functions/islandtoplist.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/islandtoplist.sk
@@ -211,37 +211,3 @@ function islandtoplist(p:player,pageint:text,gui:boolean=false):
   set {_p}'s tool to 1 of {_item}
   openbook({_p})
   set {_p}'s tool to {_tool}
-
-#
-# > Function - overwritecomponentevents
-# > Paremeters:
-# > <TextComponent>the text component which should get the events overwritten.
-# > Actions:
-# > Overwrites the events of the text components to make them normal again.
-function overwritecomponentevents(msg:object) :: object:
-  {_msg}.setClickEvent(new ClickEvent(ClickEventAction.RUN_COMMAND!,null))
-  {_msg}.setHoverEvent(new HoverEvent(HoverEventAction.SHOW_TEXT!,new ComponentBuilder(null).create()))
-  return {_msg}
-
-#
-# > Function - overwritecomponentevents
-# > Paremeters:
-# > <TextComponent>the text component which should get the events overwritten.
-# > Actions:
-# > Setts a on hover event on this text component and then returns it.
-# > HoverEvent: https://ci.md-5.net/job/BungeeCord/ws/chat/target/apidocs/net/md_5/bungee/api/chat/HoverEvent.Action.html
-function sethovertextevent(msg:object,text:object) :: object:
-  replace all "\n" with " %nl%" in {_text}
-  {_msg}.setHoverEvent(new HoverEvent(HoverEventAction.SHOW_TEXT!,new ComponentBuilder({_text}).create()))
-  return {_msg}
-
-#
-# > Function - setclickcmdevent
-# > Paremeters:
-# > <TextComponent>the text component which should get the events overwritten.
-# > Actions:
-# > Sets the click event to this text component and then returns it.
-# > ClickEvent: https://ci.md-5.net/job/BungeeCord/ws/chat/target/apidocs/net/md_5/bungee/api/chat/ClickEvent.Action.html
-function setclickcmdevent(msg:object,cmd:object) :: object:
-  {_msg}.setClickEvent(new ClickEvent(ClickEventAction.RUN_COMMAND!,{_cmd}))
-  return {_msg}

--- a/SkyBlock/SKYBLOCK.SK/Functions/menues.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/menues.sk
@@ -46,7 +46,7 @@ function skyblockgui(p: player):
   setguiitem({_p},11,experience bottle,1,"%{SB::lang::guiexpname::%{_lang}%}%","%{SB::lang::maingui::guiislandinfo::%{_lang}%}%","make ""%{_p}%"" parsed as player execute command ""/is info %{_p}%""",true)
   set {_bnq} to book and quill
   setguiitem({_p},12,{_bnq},1,"%{SB::lang::guichallangename::%{_lang}%}%","%{SB::lang::maingui::guichallangelore::%{_lang}%}%","make ""%{_p}%"" parsed as player execute command ""/is c""",true)
-  setguiitem({_p},13,floor sign,1,"%{SB::lang::guitopname::%{_lang}%}%","%{SB::lang::maingui::guitoplore::%{_lang}%}%","make ""%{_p}%"" parsed as player execute command ""/is top""",true)
+  setguiitem({_p},13,floor sign,1,"%{SB::lang::guitopname::%{_lang}%}%","%{SB::lang::maingui::guitoplore::%{_lang}%}%","islandtoplist(""%{_p}%"" parsed as player,""1"",true)",false)
   setguiitem({_p},14,ender chest,1,"%{SB::lang::guirewardsname::%{_lang}%}%","%{SB::lang::maingui::guirewardslore::%{_lang}%}%","make ""%{_p}%"" parsed as player execute command ""/openloot""",true)
   setguiitem({_p},15,end portal frame,1,"%{SB::lang::guihubname::%{_lang}%}%","%{SB::lang::maingui::guihublore::%{_lang}%}%","make ""%{_p}%"" parsed as player execute command ""/is spawn""",true)
   setguiitem({_p},16,jungle leaves,1,"&r&6&l%{SB::lang::bc::changebiomeheader::%{_lang}%}%","&r%{SB::lang::bc::changebiomemenulore::%{_lang}%}%","make ""%{_p}%"" parsed as player execute command ""/is biome""",true)

--- a/SkyBlock/SKYBLOCK.SK/Functions/openbook.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/openbook.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# openbook.sk v0.0.1
+# openbook.sk v0.0.2
 # ==============
 # Opens a book from the server side on the client.
 # ==============
@@ -32,7 +32,13 @@ import:
   {@nms}.MinecraftKey
   {@nms}.PacketDataSerializer
   {@nms}.PacketPlayOutCustomPayload
-
+  net.md_5.bungee.api.chat.TextComponent
+  net.md_5.bungee.api.chat.BaseComponent
+  net.md_5.bungee.api.chat.ComponentBuilder
+  net.md_5.bungee.api.chat.ClickEvent
+  net.md_5.bungee.api.chat.HoverEvent
+  net.md_5.bungee.api.chat.HoverEvent$Action as HoverEventAction
+  net.md_5.bungee.api.chat.ClickEvent$Action as ClickEventAction
 #
 # > Function - openbook
 # > Parameters:
@@ -49,3 +55,37 @@ function openbook(player:player):
     {_buffer}.writerIndex(1)
     set {_packet} to new PacketPlayOutCustomPayload(new MinecraftKey("minecraft:book_open"), new PacketDataSerializer({_buffer}))
     {_player}.getHandle().playerConnection!.sendPacket({_packet})
+
+#
+# > Function - overwritecomponentevents
+# > Paremeters:
+# > <TextComponent>the text component which should get the events overwritten.
+# > Actions:
+# > Overwrites the events of the text components to make them normal again.
+function overwritecomponentevents(msg:object) :: object:
+  {_msg}.setClickEvent(new ClickEvent(ClickEventAction.RUN_COMMAND!,null))
+  {_msg}.setHoverEvent(new HoverEvent(HoverEventAction.SHOW_TEXT!,new ComponentBuilder(null).create()))
+  return {_msg}
+
+#
+# > Function - overwritecomponentevents
+# > Paremeters:
+# > <TextComponent>the text component which should get the events overwritten.
+# > Actions:
+# > Setts a on hover event on this text component and then returns it.
+# > HoverEvent: https://ci.md-5.net/job/BungeeCord/ws/chat/target/apidocs/net/md_5/bungee/api/chat/HoverEvent.Action.html
+function sethovertextevent(msg:object,text:object) :: object:
+  replace all "\n" with " %nl%" in {_text}
+  {_msg}.setHoverEvent(new HoverEvent(HoverEventAction.SHOW_TEXT!,new ComponentBuilder({_text}).create()))
+  return {_msg}
+
+#
+# > Function - setclickcmdevent
+# > Paremeters:
+# > <TextComponent>the text component which should get the events overwritten.
+# > Actions:
+# > Sets the click event to this text component and then returns it.
+# > ClickEvent: https://ci.md-5.net/job/BungeeCord/ws/chat/target/apidocs/net/md_5/bungee/api/chat/ClickEvent.Action.html
+function setclickcmdevent(msg:object,cmd:object) :: object:
+  {_msg}.setClickEvent(new ClickEvent(ClickEventAction.RUN_COMMAND!,{_cmd}))
+  return {_msg}

--- a/SkyBlock/lang/de.sk
+++ b/SkyBlock/lang/de.sk
@@ -175,7 +175,6 @@ on script load:
   #
   set {SB::lang::istopheader::%{_lang}%} to " &eTop 10 &6&l(<currentpage>/<allpages>)"
   set {SB::lang::istoplist::%{_lang}%} to "&7&l<rank>&8 | &8<name>"
-  set {SB::lang::istoprankinfo::%{_lang}%} to "&eDu bist auf Platz <rank> von <islands> Inseln."
   set {SB::lang::toplistbookhover::%{_lang}%} to "<name>%nl%%{SB::config::guispacer}%%nl%&r&7Rang: <rank>%nl%Insellevel: <level>%nl%%{SB::config::guispacer}%"
 
   #
@@ -212,7 +211,7 @@ on script load:
   set {SB::lang::guigraslore::%{_lang}%} to "&9&lStarte eine Insel"
   set {SB::lang::guiexpname::%{_lang}%} to "&9&lInselinformationen"
   set {SB::lang::guichallangename::%{_lang}%} to "&a&lTägliche Aufgaben"
-  set {SB::lang::guitopname::%{_lang}%} to "&c&lTop &n10"
+  set {SB::lang::guitopname::%{_lang}%} to "&6&lBestenliste"
   set {SB::lang::guirewardsname::%{_lang}%} to "&d&lLootboxen"
   set {SB::lang::guihubname::%{_lang}%} to "%{_p1}%&lLobby"
   set {SB::lang::guibacktopreviousmenu::%{_lang}%} to "Zurück"
@@ -223,7 +222,7 @@ on script load:
   set {SB::lang::maingui::guigrasscreatelore::%{_lang}%} to "%{_s1}%Erstelle eine neue\n%{_s1}%Insel für dich."
   set {SB::lang::maingui::guiislandinfo::%{_lang}%} to "%{_s1}%Zeige Informationen\n%{_s1}%über deine Insel an."
   set {SB::lang::maingui::guichallangelore::%{_lang}%} to "%{_s1}%Öffne das das Herausforderungs-\n%{_s1}%menü, um Herausforderungen zu sehen."
-  set {SB::lang::maingui::guitoplore::%{_lang}%} to "%{_s1}%Zeigt dir die aktuelle Top 10\n%{_s1}%der besten Inseln an."
+  set {SB::lang::maingui::guitoplore::%{_lang}%} to "%{_s1}%Zeigt dir die aktuelle\n%{_s1}%Bestenliste aller\n%{_s1}%Inseln an."
   set {SB::lang::maingui::guirewardslore::%{_lang}%} to "%{_s1}%Hole dir wertvolle Belohnungen\n%{_s1}%für deine Insel ab."
   set {SB::lang::maingui::guihublore::%{_lang}%} to "%{_s1}%Teleportiert dich zur Lobby."
   set {SB::lang::maingui::guilanglore::%{_lang}%} to "%{_s1}%Ändere deine Sprache."

--- a/SkyBlock/lang/de.sk
+++ b/SkyBlock/lang/de.sk
@@ -174,8 +174,9 @@ on script load:
   # > /island top
   #
   set {SB::lang::istopheader::%{_lang}%} to " &eTop 10 &6&l(<currentpage>/<allpages>)"
-  set {SB::lang::istoplist::%{_lang}%} to "&e&l<rank>&8 - &6<leader>&7&l: &e<points> &7||&8 <members>"
+  set {SB::lang::istoplist::%{_lang}%} to "&7&l<rank>&8 | &8<name>"
   set {SB::lang::istoprankinfo::%{_lang}%} to "&eDu bist auf Platz <rank> von <islands> Inseln."
+  set {SB::lang::toplistbookhover::%{_lang}%} to "<name>%nl%%{SB::config::guispacer}%%nl%&r&7Rang: <rank>%nl%Insellevel: <level>%nl%%{SB::config::guispacer}%"
 
   #
   # > /isadmin - command feedback
@@ -234,7 +235,7 @@ on script load:
   #
   # > Chat headers
   #
-  set {SB::lang::topheader::%{_lang}%} to "&lTop 10 Inseln"
+  set {SB::lang::topheader::%{_lang}%} to "&lBestenliste (<start>/<end>)"
   set {SB::lang::levelheader::%{_lang}%} to " %{_p2}%Insel Level %{_s1}%&l- %{_p1}%"
   set {SB::lang::votereward::%{_lang}%} to "&bVote für Belohnungen: "
   set {SB::lang::rewardwoods::%{_lang}%} to "%{_p1}%Holzkiste"


### PR DESCRIPTION
This pull request aims to add books as a toplist instead of the chat. That prevents the chat from being cluttered up with data.

Also, this is somewhat more unique than normal chat messages.

- [x] Toplists are working as expected
- [x] No errors on load