### PR TITLE
Added getTranslatableComponentFromItem

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Functions/openbook.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/openbook.sk
@@ -39,6 +39,8 @@ import:
   net.md_5.bungee.api.chat.HoverEvent
   net.md_5.bungee.api.chat.HoverEvent$Action as HoverEventAction
   net.md_5.bungee.api.chat.ClickEvent$Action as ClickEventAction
+  net.md_5.bungee.api.chat.TranslatableComponent
+
 #
 # > Function - openbook
 # > Parameters:
@@ -107,4 +109,3 @@ function getTranslatableComponentFromItem(item:item) :: object:
     set {_vname} to "item.%{_vname}%"
   set {_item} to new TranslatableComponent({_vname})
   return new TranslatableComponent({_vname})
-

--- a/SkyBlock/SKYBLOCK.SK/Functions/openbook.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/openbook.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# openbook.sk v0.0.2
+# openbook.sk v0.0.3
 # ==============
 # Opens a book from the server side on the client.
 # ==============
@@ -89,3 +89,22 @@ function sethovertextevent(msg:object,text:object) :: object:
 function setclickcmdevent(msg:object,cmd:object) :: object:
   {_msg}.setClickEvent(new ClickEvent(ClickEventAction.RUN_COMMAND!,{_cmd}))
   return {_msg}
+
+#
+# > Function - getTranslatableComponentFromItem
+# > Parameters:
+# > <item>the item which is needed as translatable component
+# > Actions:
+# > Converts the item stack to a translatable component, which
+# > is going to be translated client side. That means, no translation
+# > on server side is needed.
+function getTranslatableComponentFromItem(item:item) :: object:
+  set {_vname} to "%vanilla name of {_item}%"
+  replace all ":" with "." in {_vname}
+  if {_item}.getType().isBlock() is true:
+    set {_vname} to "block.%{_vname}%"
+  else:
+    set {_vname} to "item.%{_vname}%"
+  set {_item} to new TranslatableComponent({_vname})
+  return new TranslatableComponent({_vname})
+


### PR DESCRIPTION
This function allows now to convert a ItemStack into a client side translateable component.

This is an important change which allows the following issues to be worked on:
- https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/180
- https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/175

Here is an exampe how it works:
```
command /testmsg:
  trigger:
    set {_item} to player's tool
    set {_msg} to new TextComponent("You're currently holding %{_item}.getAmount()% of ")
    set {_translated} to getTranslatableComponentFromItem({_item})
    {_msg}.addExtra({_translated})
    {_msg}.addExtra(new TextComponent(" in your hand."))
    player.sendMessage({_msg})
```

- [x] Loaded without errors
- [x] Test worked out fine