### PR TITLE
 Add calculation for contents of chests, storage units

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Functions/calcisland.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/calcisland.sk
@@ -24,7 +24,10 @@ function calcisland(p:offline player):
   #
   # > Get the location of the bedrock of the island the player is on:
   set {_bedrock} to block at {SB::player::%{_uuid}%::island::bedrock}
-
+  #
+  # > Set a local variable for chest and storage unit calculation.
+  set {_calculatechest} to yaml value "calcinventory" from "plugins/Skript/scripts/SkyBlock/config/blocks.yml"
+  set {_calculatestorage} to yaml value "calcstorage" from "plugins/Skript/scripts/SkyBlock/config/blocks.yml"
   #
   # > Prevent chunks from unloading.
   set metadata value "nochunkunload" of getdummy() to true
@@ -65,7 +68,7 @@ function calcisland(p:offline player):
   else:
     set {_loops} to 1
   set {_needed} to 0
-  set {_progress} to "%{SB::config::color::secondary::2}%||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||&r"
+  set {_progress} to "%{SB::config::color::background::1}%||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||&r"
   #
   # > If the nether islands are enabled, this function has to loop two times through the two islands (normal and nether).
   loop {_loops} times:
@@ -95,6 +98,41 @@ function calcisland(p:offline player):
           set {_tb} to "%loop-block-2.getType()%"
           if loop-block-2 is a hopper:
             add 1 to {_hopper}
+          #
+          # > If the looped block as a inventory, check if it is a
+          # > storage unit or a normal inventory block.
+          if loop-block-2's inventory is set:
+            set {_storage} to false
+            #
+            # > If the slot 26 of the inventory is clay and has "STORAGE" on the
+            # > 2nd line of the clay item, it is a storage unit.
+            if slot 26 of loop-block-2's inventory is clay:
+              if line 2 of lore of slot 26 of loop-block-2's inventory is "STORAGE":
+                set {_storage} to true
+                #
+                # > If storage calculation is enabled, add the contents experience
+                # > values to the island experience.
+                if {_calculatestorage} is true:
+                  set {_itemdata} to slot 26 of loop-block-2's inventory
+                  set {_savedamount} to line 1 of lore of {_itemdata} parsed as number
+                  set {_storeditem} to slot 0 of loop-block-2's inventory
+                  set {_tbi} to "%{_storeditem}.getType()%"
+                  set {_add} to {_blockexp::%{_tbi}%} * {_savedamount}
+                  add {_add} to {_exp}
+            #
+            # > If it isn't a storage unit and chest calculation is enabled,
+            # > loop through the inventory and add the experience values of the
+            # > items to the island experience.
+            if {_storage} is false:
+              if {_calculatechest} is true:
+                loop all items in loop-block-2's inventory:
+                  set {_item} to loop-item
+                  set {_tbi} to "%{_item}.getType()%"
+                  if {_blockexp::%{_tbi}%} is set:
+                    set {_add} to {_blockexp::%{_tbi}%} * "%{_item}.getAmount()%" parsed as number
+                    add {_add} to {_exp}
+          #
+          # > If there is experience set for this block, add it to the island experience.
           if {_blockexp::%{_tb}%} is set:
             #
             # > Add the experience of the block to the local experience variable {_exp}
@@ -109,12 +147,12 @@ function calcisland(p:offline player):
         # > If the percentage is bigger than the one before, replace one of the | progress bars with a colored one.
         if {_percent} >= {_needed}:
           add 1 to {_needed}
-          replace all "%{SB::config::color::secondary::2}%|" with "%{SB::config::color::primary::1}%|%{SB::config::color::secondary::2}%" in {_progress}
+          replace all "%{SB::config::color::background::1}%|" with "%{SB::config::color::primary::1}%|%{SB::config::color::background::1}%" in {_progress}
         #
         # > Send the current progress bar to the player.
         if {_blocks} > {_size}:
           set {_blocks} to {_size}
-        actionbar({_p},"%{_progress}% %{SB::config::color::secondary::2}%[%{_blocks}%%{SB::config::color::primary::1}%/%{SB::config::color::secondary::2}%%{_size}%]")
+        actionbar({_p},"%{_progress}% %{SB::config::color::background::1}%[%{_blocks}%%{SB::config::color::primary::1}%/%{SB::config::color::background::1}%%{_size}%]")
         #
         # > Set the counter back to 0 to do this again in 5000 blocks.
         set {_i} to 0

--- a/SkyBlock/config/blocks.yml
+++ b/SkyBlock/config/blocks.yml
@@ -6,6 +6,12 @@
 # ==============
 version: x
 #
+# > Calculate inventory of chests. Default: false.
+calcinventory: false
+#
+# > Calculate contents of storage units. Default: false.
+calcstorage: false
+#
 # > You can give the blocks here experience, if a player has the block on
 # > his island, the island level will increase once it is calculated.
 blocks:


### PR DESCRIPTION
This pull request adds a block inventory search option to the island calculation. Then, items in blocks can be added to the calculation if enabled. By default not enabled.

Close https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/179 once merged.

- [x] Calculation works
- [x] No errors on load