### PR TITLE
Added dynamic challenge repeat amounts

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Functions/challenges.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/challenges.sk
@@ -483,3 +483,35 @@ function changechallengexp(player:offline player,action:text,amount:number) :: n
   else if {_action} is "remove":
     remove {_amount} from {SB::island::%{_x}%_%{_y}%_%{_z}%::challengexp}
     return {_amount}
+
+#
+# > Function - getcurrentrepeats
+# > Parameters:
+# > <number>experience of the player
+# > <number>repeats of the challenge
+# > Actions:
+# > Returns the current repeat amount which the player is allowed to do. This
+# > is not static, since the amount can increase over the time with increasing
+# > challenge experience.
+function getcurrentrepeats(experience:number, repeats:number) :: number:
+  #
+  # > Shorten the long variables to short local variables.
+  set {_neededxp} to {SB::config::challenges::repeatmodifier::xprepeatincrease}
+  set {_repeatincrease} to {SB::config::challenges::repeatmodifier::repeatincrease}
+  set {_diffincrease} to {SB::config::challenges::repeatmodifier::difficulty}
+  #
+  # > While loop as long we're not done.
+  while {_done} is not set:
+    #
+    # > If the experience is equal or bigger than the needed xp,
+    # > increase the repeats and needed xp counter.
+    if {_experience} >= {_neededxp}:
+      set {_neededxp} to (({_neededxp}/100)*{_diffincrease})+{_neededxp}
+	  set {_repeats} to (({_repeats}/100)*{_repeatincrease})+{_repeatincrease}
+    #
+    # > If there is not enough experience, we're done here, return.
+	else:
+      set {_done} to true
+  delete {_done}
+  return {_repeats}
+

--- a/SkyBlock/SKYBLOCK.SK/Functions/challenges.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/challenges.sk
@@ -108,6 +108,37 @@ function openchallenges(p:player,page:number=0):
     set {_xplang} to getlang("challenge_xp",{_lang})
     replace all "<amount>" with "%{_xp}%" in {_xplang}
     setguiitem({_p},22,{_p}'s skull,1,"&r%{SB::robot::stats::%{_lang}%}%","%{_xplang}%"," ",false)
+    set {_repeatbonus} to getcurrentrepeats({_xp},100)
+    remove 100 from {_repeatbonus}
+    #
+    # > Calculate repeat statistic.
+    set {_neededxp} to {SB::config::challenges::repeatmodifier::xprepeatincrease}
+    set {_repeatincrease} to {SB::config::challenges::repeatmodifier::repeatincrease}
+    set {_diffincrease} to {SB::config::challenges::repeatmodifier::difficulty}
+    set {_startrepeats} to 100
+    #
+    # > While loop as long we're not done.
+    while {_done} is not set:
+      #
+      # > If the experience is equal or bigger than the needed xp,
+      # > increase the repeats and needed xp counter.
+      if {_xp} >= {_neededxp}:
+        set {_neededxp} to (({_neededxp}/100)*{_diffincrease})+{_neededxp}
+        set {_repeats} to (({_repeats}/100)*{_repeatincrease})+{_repeats}
+      #
+      # > If there is not enough experience, we're done here, return.
+      else:
+        set {_done} to true
+    #
+    # > Calculate the progress in percent until the new repeat bonus is hit.
+    set {_progress} to ({_xp}/{_neededxp})*100
+    #
+    # > Display the repeat bonus statistic item.
+    getlang("challenge_repeatbonustitle",{_lang})
+    set {_lore} to getlang("challenge_repeatbonuslore",{_lang})
+    replace all "<bonus>" with "%{_repeatbonus}%" in {_lore}
+    replace all "<progress>" with "%{_progress}%" in {_lore}
+    setguiitem({_p},24,magenta glazed terracotta,1,getlang("challenge_repeatbonustitle",{_lang}),{_lore}," ",false)
   else:
     set {_item} to getcustomhead("blackexclamation", "%{_lvlhead::exclamation}%")
     setguiitem({_p},45,{_item},1,"&r%{_name}%","&r%{_lore}%","openchallenges(""%{_p}%"" parsed as player,0)",false)
@@ -512,6 +543,7 @@ function getcurrentrepeats(experience:number, repeats:number) :: number:
   set {_neededxp} to {SB::config::challenges::repeatmodifier::xprepeatincrease}
   set {_repeatincrease} to {SB::config::challenges::repeatmodifier::repeatincrease}
   set {_diffincrease} to {SB::config::challenges::repeatmodifier::difficulty}
+  set {_startrepeats} to {_repeats}
   #
   # > While loop as long we're not done.
   while {_done} is not set:
@@ -525,5 +557,6 @@ function getcurrentrepeats(experience:number, repeats:number) :: number:
     # > If there is not enough experience, we're done here, return.
     else:
       set {_done} to true
+  add {_startrepeats} to {_repeats}
   delete {_done}
   return round({_repeats})

--- a/SkyBlock/SKYBLOCK.SK/Functions/challenges.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/challenges.sk
@@ -164,6 +164,9 @@ function renderchallengeitems(player:player,page:number,currentxp:number=0):
   set {_x} to x-coord of {_bedrock}
   set {_y} to y-coord of {_bedrock}
   set {_z} to z-coord of {_bedrock}
+  set {_xp} to {SB::island::%{_x}%_%{_y}%_%{_z}%::challengexp}
+  if {_xp} is not set:
+    set {_xp} to 0
   #
   # > Get island challenge data for repeats.
   set {_islandchallengedata} to {SB::island::%{_x}%_%{_y}%_%{_z}%::challenges}
@@ -260,6 +263,10 @@ function renderchallengeitems(player:player,page:number,currentxp:number=0):
           # > If the server operator set the repeat amount per day to -1, it is endless.
           if {_max} is -1:
             set {_max} to "∞"
+          #
+          # > If tthe current repeats aren't unlimited, calculate the maximum amount.
+          else:
+            set {_max} to getcurrentrepeats({_xp},{_max})
           replace all "<current>" with "%{_c}%" in {_m}
           replace all "<maxrepeat>" with "%{_max}%" in {_m}
           set {_loreend} to "%{_loreend}%%{_m}%"
@@ -307,6 +314,12 @@ function solvechallenge(p:player,challenge:text,page:number=0,shift:boolean=fals
   set {_x} to x-coord of {_bedrock}
   set {_y} to y-coord of {_bedrock}
   set {_z} to z-coord of {_bedrock}
+  #
+  # > Get challenge experience and calculate maximum repeats for this challenge.
+  set {_xp} to {SB::island::%{_x}%_%{_y}%_%{_z}%::challengexp}
+  if {_xp} is not set:
+    set {_xp} to 0
+  set {_repeatsperday} to getcurrentrepeats({_xp},{_repeatsperday})
   #
   # > Split the string to a array. (challenge level=1,challenge id=3=repeats 5 amount == 13=5)
   # > Get repeat amount: {_finalchallenges::%{_cid}%}
@@ -507,11 +520,10 @@ function getcurrentrepeats(experience:number, repeats:number) :: number:
     # > increase the repeats and needed xp counter.
     if {_experience} >= {_neededxp}:
       set {_neededxp} to (({_neededxp}/100)*{_diffincrease})+{_neededxp}
-	  set {_repeats} to (({_repeats}/100)*{_repeatincrease})+{_repeatincrease}
+      set {_repeats} to (({_repeats}/100)*{_repeatincrease})+{_repeats}
     #
     # > If there is not enough experience, we're done here, return.
-	else:
+    else:
       set {_done} to true
   delete {_done}
-  return {_repeats}
-
+  return round({_repeats})

--- a/SkyBlock/SKYBLOCK.SK/Functions/challenges.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/challenges.sk
@@ -138,7 +138,7 @@ function openchallenges(p:player,page:number=0):
     set {_lore} to getlang("challenge_repeatbonuslore",{_lang})
     replace all "<bonus>" with "%{_repeatbonus}%" in {_lore}
     replace all "<progress>" with "%{_progress}%" in {_lore}
-    setguiitem({_p},24,magenta glazed terracotta,1,getlang("challenge_repeatbonustitle",{_lang}),{_lore}," ",false)
+    setguiitem({_p},24,{SB::config::challenges::repeatmodifier::item},1,getlang("challenge_repeatbonustitle",{_lang}),{_lore}," ",false)
   else:
     set {_item} to getcustomhead("blackexclamation", "%{_lvlhead::exclamation}%")
     setguiitem({_p},45,{_item},1,"&r%{_name}%","&r%{_lore}%","openchallenges(""%{_p}%"" parsed as player,0)",false)

--- a/SkyBlock/config/challenges.sk
+++ b/SkyBlock/config/challenges.sk
@@ -14,6 +14,22 @@ on load:
   set {SB::config::challenges::threshold::3} to 500
   set {SB::config::challenges::threshold::4} to 2500
   set {SB::config::challenges::threshold::5} to 5000
+  
+  #
+  # > Set here the amount in percent, how much the repeats should be increased per level.
+  # > 20 means 20% per defined x. 
+  set {SB::config::challenges::repeatmodifier::repeatincrease} to 20
+  #
+  # > Set the amount of xp needed for a increase of the repeats.
+  set {SB::config::challenges::repeatmodifier::xprepeatincrease} to 100
+  #
+  # > Increase the amount of the needed experience to increase the repeats
+  # > with a predefined difficulty modifier which gets harder every time the
+  # > increasement has happened.
+  set {SB::config::challenges::repeatmodifier::difficulty} to 20
+  #
+  # > Set the item which should appear to display the repeat modifier statistics.
+  set {SB::config::challenges::repeatmodifier::item} to magenta glazed terracotta
 
   #
   # > Define the challenges. Example:

--- a/SkyBlock/lang/de.yml
+++ b/SkyBlock/lang/de.yml
@@ -538,6 +538,8 @@ language:
 - challenge_notrepeatable: "&7Nicht wiederholbar."
 - challenge_xp: "&7XP: <amount>"
 - challenge_statssitelore: "&7Erhalte deine aktuelle<nl>&7Herausforderungsstatistik."
+- challenge_repeatbonustitle: "&rWiederholungsbonus"
+- challenge_repeatbonuslore: "&r&7Aktueller Bonus: <bonus>%<nl>&7Bonusfortschritt: <progress>%"
 
   #
   # > Challenge names


### PR DESCRIPTION
This pull request adds the feature mentioned at https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/197 to the challenges.


- [x] Configurable parameters (needed xp, needed xp modifier per xp needed, repeat increasement per xp needed)
- [x] Created new function: `getcurrentrepeats(experience:number, repeats:number)`
- [x] Challenges now have increasing repeats per predefined xp
- [x] Stats item added
- [x] Loading and working without problems
