### PR TITLE
Use books for the /island help command

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Functions/islandhelp.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/islandhelp.sk
@@ -5,6 +5,11 @@
 # islandhelp.sk is part of the SKYBLOCK.SK functions.
 # ==============
 
+import:
+  org.bukkit.inventory.ItemStack
+  org.bukkit.Material
+
+#
 # > Function - islandhelp:
 # > Arguments:
 # > <player>player, <text>site integer as text
@@ -17,41 +22,61 @@ function islandhelp(p:player,site:text="1"):
   set {_lang} to getlangcode({_p})
   set {_prefix} to getlang("prefix",{_lang})
   #
-  # > If the player defined a not existing site, send error and stop.
-  if {_site} > 5:
-    message "%{_prefix}% %getlang(""helpsiteerror"",{_lang})%" to {_p}
-    stop
-  if {_site} < 1:
-    message "%{_prefix}% %getlang(""helpsiteerror"",{_lang})%" to {_p}
-    stop
+  # > Set a new ComponentBuilder to create book pages.
+  set {_book} to newComponentBuilder()
   #
-  # > Send the player the help depending on the defined site.
-  send "%{SB::config::spacer}%" to {_p}
-  if {_site} is 1:
-    message "%{_prefix}% %getlang(""iscreate"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""isdelete"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""isteleport"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""issethome"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""isteleportgo"",{_lang})%" to {_p}
-  else if {_site} is 2:
-    message "%{_prefix}% %getlang(""islevel"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""istop"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""isinvite"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""iskick"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""isjoin"",{_lang})%" to {_p}
-  else if {_site} is 3:
-    message "%{_prefix}% %getlang(""isleave"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""isgui"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""isspawn"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""isore"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""isgen"",{_lang})%" to {_p}
-  else if {_site} is 4:
-    message "%{_prefix}% %getlang(""trustadd"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""trustremove"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""trustlist"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""helpwarp"",{_lang})%" to {_p}
-    message "%{_prefix}% %getlang(""helpsetwarp"",{_lang})%" to {_p}
-  else if {_site} is 5:
-    message "%{_prefix}% %getlang(""helpdelwarp"",{_lang})%" to {_p}
-  send "%{_prefix}% &7%getlang(""helps2"",{_lang})%: %{_site}%/5 - %getlang(""helpsiteerror"",{_lang})%" to {_p}
-  send "%{SB::config::spacer}%" to {_p}
+  # > Add all commands and the order in which it should be displayed to the player.
+  # > These need to have the same name as defined in the language files.
+  add "iscreate","isdelete","isteleport","issethome","isteleportgo","islevel","istop","isinvite","iskick","isjoin" to {_commands::*}
+  add "isleave","isgui","isspawn","isore","isgen","trustadd","trustremove","trustlist","helpwarp","helpsetwarp" to {_commands::*}
+  add "helpdelwarp" to {_commands::*}
+  set {_i} to 0
+  loop {_commands::*}:
+    #
+	# > If this is a new page (counter is 0), add a header to the site.
+    if {_i} is 0:
+      {_book}.append(newTextComponent(getlang("help-header",{_lang},""," %nl%")))
+      {_book}.append(newTextComponent("%{SB::config::bookspacer}%"))
+    add 1 to {_i}
+    #
+    # > Get all the translations to add them into the page.
+    set {_title} to getlang("help-title-%loop-value%",{_lang})
+    set {_desc} to getlang("help-desc-%loop-value%",{_lang})
+    set {_cmd} to getlang("help-cmd-%loop-value%",{_lang})
+    set {_msg} to newTextComponent("%nl%%{_cmd}%")
+    set {_msg} to sethovertextevent({_msg}, "%{_title}%\n%{_desc}%%nl%%{SB::config::guispacer}%&r%nl%%{_cmd}%%nl%%{SB::config::guispacer}%")
+    {_book}.append({_msg})
+    #
+    # > Add a spacer which overwrites any events.
+    set {_msg} to newTextComponent("%nl%%{SB::config::bookspacer}%")
+    set {_msg} to overwritecomponentevents({_msg})
+    {_book}.append({_msg})
+    #
+    # > Make a new site every 5 commands.
+    if {_i} >= 5:
+      add {_book}.create() to {_sites::*}
+      set {_book} to newComponentBuilder()
+      set {_i} to 0
+  #
+  # > Add the current page to the sites list.
+  add {_book}.create() to {_sites::*}
+  #
+  # > Create a new book which is going to be used, create it as Bukkit ItemStack to prevent
+  # > Skript side bugs.
+  set {_item} to new ItemStack(Material.WRITTEN_BOOK!, 1)
+  set {_bookmeta} to {_item}.getItemMeta()
+  #
+  # > Set the title and the author, this is not displayed but
+  # > needed to function.
+  {_bookmeta}.setTitle("Help")
+  {_bookmeta}.setAuthor("Immanuel94")
+  #
+  # > Set the sites to the book and then open it to the player.
+  {_bookmeta}.spigot().setPages({_sites::*})
+  {_item}.setItemMeta({_bookmeta})
+  #
+  # > Get the item of the player to give it back after the book has been opened.
+  set {_tool} to {_p}'s tool
+  set {_p}'s tool to {_item}
+  openbook({_p})
+  set {_p}'s tool to {_tool}

--- a/SkyBlock/SKYBLOCK.SK/Functions/openbook.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/openbook.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# openbook.sk v0.0.7
+# openbook.sk v0.0.8
 # ==============
 # Opens a book from the server side on the client.
 # ==============
@@ -84,12 +84,25 @@ function sethovertextevent(msg:object,text:object) :: object:
 #
 # > Function - setclickcmdevent
 # > Paremeters:
-# > <TextComponent>the text component which should get the events overwritten.
+# > <TextComponent>the TextComponen which should get a click event
+# > <text>a text which should be executed from the client of the player
 # > Actions:
 # > Sets the click event to this text component and then returns it.
 # > ClickEvent: https://ci.md-5.net/job/BungeeCord/ws/chat/target/apidocs/net/md_5/bungee/api/chat/ClickEvent.Action.html
 function setclickcmdevent(msg:object,cmd:object) :: object:
   {_msg}.setClickEvent(new ClickEvent(ClickEventAction.RUN_COMMAND!,{_cmd}))
+  return {_msg}
+
+#
+# > Function - setsuggestcmdevent
+# > Paremeters:
+# > <TextComponent>the TextComponen which should get a click event
+# > <text>a text which should be suggested into the client of the player
+# > Actions:
+# > Sets the suggest command event to this text component and then returns it.
+# > ClickEvent: https://ci.md-5.net/job/BungeeCord/ws/chat/target/apidocs/net/md_5/bungee/api/chat/ClickEvent.Action.html
+function setsuggestcmdevent(msg:object,cmd:object) :: object:
+  {_msg}.setClickEvent(new ClickEvent(ClickEventAction.SUGGEST_COMMAND!,{_cmd}))
   return {_msg}
 
 #

--- a/SkyBlock/config/look.sk
+++ b/SkyBlock/config/look.sk
@@ -17,7 +17,9 @@ on load:
   #
   # > If a spacer is needed in the chat, this is used as a spacer:
   set {SB::config::spacer} to "%{SB::config::color::secondary::2}%&l&m---------------------------------------------"
-
+  #
+  # > If a spacer is needed in a book, this is used:
+  set {SB::config::bookspacer} to "%{SB::config::color::secondary::2}%&l>------------"
   #
   # > If a spacer is needed in the item gui, this is used as a spacer:
   set {SB::config::guispacer} to "%{SB::config::color::background::1}%&l&m-----------"

--- a/SkyBlock/lang/de.yml
+++ b/SkyBlock/lang/de.yml
@@ -107,74 +107,74 @@ language:
 
   #
   # > /island help
-- help-title-iscreate: <p1>&lInsel erstellen
+- help-header: <p1>&lHilfe
+- help-title-iscreate: <p1>Insel erstellen
 - help-desc-iscreate: <s1>Erstellt eine Insel
 - help-cmd-iscreate: /is create
-- help-title-isdelete: <p1>&lInsel löschen
-- help-desc-isdelete: <s1>löscht deine Insel
+- help-title-isdelete: <p1>Insel löschen
+- help-desc-isdelete: <s1>Löscht deine Insel
 - help-cmd-isdelete: /is delete
-- help-title-isteleport: <p2>&lZum Zuhause teleportiere <s1>- <p1>/is home
-- help-desc-isteleport: <p2>Teleportiert dich zum Zuhause der Insel
-- help-cmd-isteleport: /is home
-- help-title-issethome: <p2>Zuhause setzen
-- help-desc-issethome: <p2>Setzt ein Zuhause an dem aktuellen Standort.
-- help-cmd-issethome: /is sethome
-- help-title-isteleportgo: <p2>&lZum Grundstein teleportieren <s1>- <p1>/is go
-- help-desc-isteleportgo: <p2>Teleportiert dich zum Grundstein deiner Insel.
+- help-title-isteleport: <p1>Teleport nachhause
+- help-desc-isteleport: <s1>Teleportiert dich<nl><s1>zum Zuhause der Insel
+- help-cmd-isteleport: /is home [<Name>]
+- help-title-issethome: <p1>Zuhause setzen
+- help-desc-issethome: <s1>Setzt ein Zuhause an<nl><s1>dem aktuellen Standort.
+- help-cmd-issethome: /is sethome [<Name>]
+- help-title-isteleportgo: <p1>Zum Grundstein
+- help-desc-isteleportgo: <s1>Teleportiert dich zum<nl><s1>Grundstein deiner Insel.
 - help-cmd-isteleportgo: /is go
 - help-title-islevel: <p1>Insel Level
-- help-desc-islevel: Zeigt dein aktuelles Insellevel an.
+- help-desc-islevel: <s1>Zeigt dein aktuelles Insellevel an.
 - help-cmd-islevel: /is level
 - help-title-istop: <p1>Bestenliste
-- help-desc-istop: <p1>Zeigt eine Bestenliste an, auf der die Inseln mit den höchsten Leveln angezeigt werden.
+- help-desc-istop: <s1>Zeigt eine Bestenliste an,<nl><s1>auf der die Inseln mit den<nl><s1>höchsten Leveln angezeigt<nl><s1>werden.
 - help-cmd-istop: /is top
 - help-title-isinvite: <p1>Spieler einladen
-- help-desc-isinvite: <p1>Lädt einen Spieler auf deine Insel ein.
-- help-cmd-isinvite: /is invite 
+- help-desc-isinvite: <s1>Lädt einen Spieler auf deine Insel ein.
+- help-cmd-isinvite: /is invite <Spieler>
 - help-title-iskick: <p1>Spieler rauswerfen
-- help-desc-iskick: <p1>Wirft einen Spieler von deiner Insel.
-- help-cmd-iskick: /is kick 
+- help-desc-iskick: <s1>Wirft einen Spieler von deiner Insel.
+- help-cmd-iskick: /is kick <Spieler>
 - help-title-isjoin: <p1>Einladung annehmen
-- help-desc-isjoin: <p1>Nimmt eine Einladung an.
+- help-desc-isjoin: <s1>Nimmt eine Einladung an.
 - help-cmd-isjoin: /is join 
 - help-title-isleave: <p1>Insel verlassen
-- help-desc-isleave: <p1>Verlässt eine Insel auf der du gerade Mitglied bist.
+- help-desc-isleave: <s1>Verlässt eine Insel auf der<nl><s1>du gerade Mitglied bist.
 - help-cmd-isleave: /is leave
 - help-title-isgui: <p1>SkyBlock Menü
-- help-desc-isgui: <p1>Öffnet das SkyBlock Menü, von hier kannst du fast alle wichtigen Befehle über ein Menü erreichen.
+- help-desc-isgui: <s1>Öffnet das SkyBlock Menü,<nl><s1>von hier kannst du fast alle<nl><s1>wichtigen Befehle über ein<nl><s1>Menü erreichen.
 - help-cmd-isgui: /is
 - help-title-isspawn: <p1>Server Lobby
-- help-desc-isspawn: <p1>Teleportiert dich zur Lobby des Servers
+- help-desc-isspawn: <s1>Teleportiert dich zur Lobby des Servers
 - help-cmd-isspawn: /is spawn
 - help-title-isore: <p1>Erzgenerator Chancen
-- help-desc-isore: <p1>Zeigt dir die Chancen auf die Erze an, die du mit dem Erzgenerator derzeit hast.
+- help-desc-isore: <s1>Zeigt dir die Chancen auf<nl><s1>die Erze an, die du mit<nl><s1>dem Erzgenerator derzeit hast.
 - help-cmd-isore: /is ore
 - help-title-isgen: <p1>Erzgenerator Status
-- help-desc-isgen: <p1>Zeigt dir den aktuellen Status deines Erzgenerators an.
+- help-desc-isgen: <s1>Zeigt dir den aktuellen<nl><s1>Status deines Erzgenerators an.
 - help-cmd-isgen: /is gen
 - help-title-trustadd: <p1>Spielern vertrauen
-- help-desc-trustadd: <p1>Vertraue einem Spieler, für vertraute Spieler können eigene Flaggruppen erstellt werden.
-- help-cmd-trustadd: /is trust add <player>
+- help-desc-trustadd: <s1>Vertraue einem Spieler,<nl><s1>für vertraute Spieler können<nl><s1>eigene Flaggruppen erstellt werden.
+- help-cmd-trustadd: /is trust add <Spieler>
 - help-title-trustremove: <p1>Entferne vertrauten Spieler
-- help-desc-trustremove: <p1>Traue dem Spieler nicht länger.
-- help-cmd-trustremove: /is trust remove <player>
+- help-desc-trustremove: <s1>Traue dem Spieler nicht länger.
+- help-cmd-trustremove: /is trust remove <Spieler>
 - help-title-trustlist: <p1>Aktuell vertraute Spieler
-- help-desc-trustlist: <p1>Zeigt dir eine Liste mit von dir aktuell vertrauten Spielern an.
+- help-desc-trustlist: <s1>Zeigt dir eine Liste mit von<nl><s1>dir aktuell vertrauten Spielern an.
 - help-cmd-trustlist: /is trust list
 - help-title-flaglist: <p1>Flags ändern
-- help-desc-flaglist: <p1>Öffnet ein Menü in dem die Flags für die Insel geändert werden können.
+- help-desc-flaglist: <s1>Öffnet ein Menü in dem<nl><s1>die Flags für die Insel<nl><s1>geändert werden können.
 - help-cmd-flaglist: /is flags
 - help-title-helpwarp: <p1>Inselwarps
-- help-desc-helpwarp: <p1>Teleportiert dich zu einem Warp des definierten Spielers.
+- help-desc-helpwarp: <s1>Teleportiert dich zu<nl><s1>einem Warp des definierten<nl><s1>Spielers.
 - help-cmd-helpwarp: /is warp <Spieler>
 - help-title-helpsetwarp: <p1>Inselwarp setzen
-- help-desc-helpsetwarp: <p1>Settzt einen Inselwarp an deinem aktuellen Standort. Daraufhin kann dich jeder besuchen.
+- help-desc-helpsetwarp: <s1>Setzt einen Inselwarp<nl><s1>an deinem aktuellen Standort.<nl><s1>Daraufhin kann dich jeder besuchen.
 - help-cmd-helpsetwarp: /is setwarp
 - help-title-helpdelwarp: <p1>Inselwarp löschen
-- help-desc-helpdelwarp: <p1>Löscht deinen Inselwarp, daraufhin kann dich niemand mehr über deinen Inselwarp besuchen.
+- help-desc-helpdelwarp: <s1>Löscht deinen Inselwarp,<nl><s1>daraufhin kann dich niemand mehr<nl><s1>über deinen Inselwarp besuchen.
 - help-cmd-helpdelwarp: /is delwarp
 - help-title-helps2: Seite
-
 
   #
   # > /island - Errors

--- a/SkyBlock/lang/de.yml
+++ b/SkyBlock/lang/de.yml
@@ -107,29 +107,74 @@ language:
 
   #
   # > /island help
-- iscreate: <p2>&lInsel erstellen <s1>- <p1>/is create
-- isdelete: <p2>&lInsel löschen <s1>- <p1>/is delete
-- isteleport: <p2>&lZur Insel teleportieren <s1>- <p1>/is home
-- issethome: <p2>&lInsel Zuhause ändern <s1>- <p1>/is sethome
-- isteleportgo: <p2>&lZum Grundstein teleportieren <s1>- <p1>/is go
-- islevel: <p1>&l> <p2>&lInsel Level <s1>- <p1>/is level
-- istop: <p1>&l> <p2>&lTop 10 <s1>- <p1>/is top <Seite>
-- isinvite: <p1>&l> <p2>&lSpieler einladen <s1>- <p1>/is invite <Spieler>
-- iskick: <p1>&l> <p2>&lSpieler rauswerfen <s1>- <p1>/is kick <Spieler>
-- isjoin: <p1>&l> <p2>&lEinladung annehmen <s1>- <p1>/is join <Spieler>
-- isleave: <p1>&l> <p2>&lInsel verlassen <s1>- <p1>/is leave
-- isgui: <p1>&l> <p2>&lSkyblock Menü <s1>- <p1>/is
-- isspawn: <p1>&l> <p2>&lZur Lobby <s1>- <p1>/is spawn
-- isore: <p1>&l> <p2>&lErz Chancen <s1>- <p1>/is ore
-- isgen: <p1>&l> <p2>&lGenerator Level <s1>- <p1>/is gen
-- trustadd: <p1>&l> <p2>&lVertraue einem Spieler <s1>- <p1>/is trust add <player>
-- trustremove: <p1>&l> <p2>&lTraue dem Spieler nicht länger <s1>- <p1>/is trust remove <player>
-- trustlist: <p1>&l> <p2>&lListe aller vertrauten Spieler <s1>- <p1>/is trust list
-- flaglist: <p1>&l> <p2>&lÖffnet das Flag menü <s1>- <p1>/is flags
-- helpwarp: <p1>&l> <p2>&lTeleportiert zum Warp <s1>- <p1>/is warp <Spieler>
-- helpsetwarp: <p1>&l> <p2>&lSetzt deinen Inselwarp <s1>- <p1>/is setwarp
-- helpdelwarp: <p1>&l> <p2>&lLöscht deinen Inselwarp <s1>- <p1>/is delwarp
-- helps2: Seite
+- help-title-iscreate: <p1>&lInsel erstellen
+- help-desc-iscreate: <s1>Erstellt eine Insel
+- help-cmd-iscreate: /is create
+- help-title-isdelete: <p1>&lInsel löschen
+- help-desc-isdelete: <s1>löscht deine Insel
+- help-cmd-isdelete: /is delete
+- help-title-isteleport: <p2>&lZum Zuhause teleportiere <s1>- <p1>/is home
+- help-desc-isteleport: <p2>Teleportiert dich zum Zuhause der Insel
+- help-cmd-isteleport: /is home
+- help-title-issethome: <p2>Zuhause setzen
+- help-desc-issethome: <p2>Setzt ein Zuhause an dem aktuellen Standort.
+- help-cmd-issethome: /is sethome
+- help-title-isteleportgo: <p2>&lZum Grundstein teleportieren <s1>- <p1>/is go
+- help-desc-isteleportgo: <p2>Teleportiert dich zum Grundstein deiner Insel.
+- help-cmd-isteleportgo: /is go
+- help-title-islevel: <p1>Insel Level
+- help-desc-islevel: Zeigt dein aktuelles Insellevel an.
+- help-cmd-islevel: /is level
+- help-title-istop: <p1>Bestenliste
+- help-desc-istop: <p1>Zeigt eine Bestenliste an, auf der die Inseln mit den höchsten Leveln angezeigt werden.
+- help-cmd-istop: /is top
+- help-title-isinvite: <p1>Spieler einladen
+- help-desc-isinvite: <p1>Lädt einen Spieler auf deine Insel ein.
+- help-cmd-isinvite: /is invite 
+- help-title-iskick: <p1>Spieler rauswerfen
+- help-desc-iskick: <p1>Wirft einen Spieler von deiner Insel.
+- help-cmd-iskick: /is kick 
+- help-title-isjoin: <p1>Einladung annehmen
+- help-desc-isjoin: <p1>Nimmt eine Einladung an.
+- help-cmd-isjoin: /is join 
+- help-title-isleave: <p1>Insel verlassen
+- help-desc-isleave: <p1>Verlässt eine Insel auf der du gerade Mitglied bist.
+- help-cmd-isleave: /is leave
+- help-title-isgui: <p1>SkyBlock Menü
+- help-desc-isgui: <p1>Öffnet das SkyBlock Menü, von hier kannst du fast alle wichtigen Befehle über ein Menü erreichen.
+- help-cmd-isgui: /is
+- help-title-isspawn: <p1>Server Lobby
+- help-desc-isspawn: <p1>Teleportiert dich zur Lobby des Servers
+- help-cmd-isspawn: /is spawn
+- help-title-isore: <p1>Erzgenerator Chancen
+- help-desc-isore: <p1>Zeigt dir die Chancen auf die Erze an, die du mit dem Erzgenerator derzeit hast.
+- help-cmd-isore: /is ore
+- help-title-isgen: <p1>Erzgenerator Status
+- help-desc-isgen: <p1>Zeigt dir den aktuellen Status deines Erzgenerators an.
+- help-cmd-isgen: /is gen
+- help-title-trustadd: <p1>Spielern vertrauen
+- help-desc-trustadd: <p1>Vertraue einem Spieler, für vertraute Spieler können eigene Flaggruppen erstellt werden.
+- help-cmd-trustadd: /is trust add <player>
+- help-title-trustremove: <p1>Entferne vertrauten Spieler
+- help-desc-trustremove: <p1>Traue dem Spieler nicht länger.
+- help-cmd-trustremove: /is trust remove <player>
+- help-title-trustlist: <p1>Aktuell vertraute Spieler
+- help-desc-trustlist: <p1>Zeigt dir eine Liste mit von dir aktuell vertrauten Spielern an.
+- help-cmd-trustlist: /is trust list
+- help-title-flaglist: <p1>Flags ändern
+- help-desc-flaglist: <p1>Öffnet ein Menü in dem die Flags für die Insel geändert werden können.
+- help-cmd-flaglist: /is flags
+- help-title-helpwarp: <p1>Inselwarps
+- help-desc-helpwarp: <p1>Teleportiert dich zu einem Warp des definierten Spielers.
+- help-cmd-helpwarp: /is warp <Spieler>
+- help-title-helpsetwarp: <p1>Inselwarp setzen
+- help-desc-helpsetwarp: <p1>Settzt einen Inselwarp an deinem aktuellen Standort. Daraufhin kann dich jeder besuchen.
+- help-cmd-helpsetwarp: /is setwarp
+- help-title-helpdelwarp: <p1>Inselwarp löschen
+- help-desc-helpdelwarp: <p1>Löscht deinen Inselwarp, daraufhin kann dich niemand mehr über deinen Inselwarp besuchen.
+- help-cmd-helpdelwarp: /is delwarp
+- help-title-helps2: Seite
+
 
   #
   # > /island - Errors

--- a/SkyBlock/lang/de.yml
+++ b/SkyBlock/lang/de.yml
@@ -107,7 +107,7 @@ language:
 
   #
   # > /island help
-- help-header: <p1>&lHilfe
+- help-header: "&l> <p1>&lHilfe"
 - help-title-iscreate: <p1>Insel erstellen
 - help-desc-iscreate: <s1>Erstellt eine Insel
 - help-cmd-iscreate: /is create


### PR DESCRIPTION
Use books for the `/island help` command to make navigation easier and less spammy. 

Additional, it can use `hover` and `click` events to give more description and auto chat fill of the command.

Close https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/220 once merged.