### PR TITLE
Added sorted toplist & improvements of island warps

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Commands.sk
+++ b/SkyBlock/SKYBLOCK.SK/Commands.sk
@@ -256,7 +256,7 @@ command /island [<text>] [<text=1>] [<text>]:
     # > If a player types in /island with the first argument "top",
     # > the top list gets shown to the player using the islandtoplist function.
     else if arg-1 is "top":
-      islandtoplist(player,arg-2)
+      islandtoplist(player,arg-2,false,arg-3)
     #
     # > Argument: "spawn" or "lobby"
     # > Actions:

--- a/SkyBlock/SKYBLOCK.SK/Functions/islandtoplist.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/islandtoplist.sk
@@ -22,11 +22,15 @@ import:
 # > <player>player, <text>pageint
 # > Actions:
 # > The islandtoplist sends a toplist into the chat of the player.
-function islandtoplist(p:player,pageint:text,gui:boolean=false):
+function islandtoplist(p:player,pageint:text,gui:boolean=false,sorted:text="island"):
   #
   # > Wait a short time to prevent client side bugs
   if {_gui} is true:
     wait 2 ticks
+  #
+  # > Check if the sorted variable is valid:
+  if {_sorted} is not "island" or "challenge" or "visitors":
+    set {_sorted} to "island"
   #
   # > Save some variables to local variables.
   set {_pageint} to "%{_pageint}%" parsed as number
@@ -51,15 +55,38 @@ function islandtoplist(p:player,pageint:text,gui:boolean=false):
     message "%{_prefix}% %{_msg}%" to {_p}
     stop
   #
-  # > Loop through all island levels.
-  loop {SB::islvl::*}:
+  # > Go trough this if we want the island toplist.
+  if {_sorted} is "island":
     #
-    # > If there is already a level set for this island, delete the list entry.
-    if {_level::%loop-index%} is set:
-      delete {SB::islvl::%loop-index%}
+    # > Get the island levels as local variable.
+    loop {SB::islvl::*}:
+      #
+      # > If there is already a level set for this island, delete the list entry.
+      if {_level::%loop-index%} is set:
+        delete {SB::islvl::%loop-index%}
+      #
+      # > Set the entries to a new list to sort it, do not mess with the list saved on disk.
+      set {_level::%loop-index%} to loop-value
+  #
+  # > Go through this part if the challenge toplist is wanted.
+  else if {_sorted} is "challenge":
     #
-    # > Set the entries to a new list to sort it, do not mess with the list saved on disk.
-    set {_level::%loop-index%} to loop-value
+    # > Get the challenge experience as local variable.
+    loop {SB::islvl::*}:
+      if {SB::island::%loop-index%::challengexp} is 0:
+        set {_level::%loop-index%} to 0
+      else:
+        set {_level::%loop-index%} to {SB::island::%loop-index%::challengexp}
+  #
+  # > Go through this part if the visitors toplist is wanted.
+  else if {_sorted} is "visitors":
+    #
+    # > Get the visitors as local variable.
+    loop {SB::islvl::*}:
+      if {SB::visits::%loop-index%} is 0:
+        set {_level::%loop-index%} to 0
+      else:
+        set {_level::%loop-index%} to {SB::visits::%loop-index%}
   #
   # > Revert the list from random to low to high. {_l2h::*} -> l2h means low to high.
   loop {_level::*}:
@@ -113,7 +140,35 @@ function islandtoplist(p:player,pageint:text,gui:boolean=false):
   set {_line} to getlang("topheader",{_lang})
   replace all "<start>" with "%{_pageint}%" in {_line}
   replace all "<end>" with "%{_page}%" in {_line}
-  {_book}.append(newTextComponent("%{_line}%%nl%%nl%"))
+  {_book}.append(newTextComponent("%{_line}%%nl%"))
+  {_book}.append(newTextComponent(getlang("islandtoplist_sortby",{_lang})))
+  if {_sorted} is "island":
+    set {_prefix} to "&l"
+  else:
+    set {_prefix} to "&r"
+  set {_msg} to newTextComponent(getlang("islandtoplist_island",{_lang},{_prefix}))
+  set {_msg} to setclickcmdevent({_msg},"/island top 1")
+  set {_msg} to sethovertextevent({_msg},getlang("islandtoplist_island_hover",{_lang}))
+  {_book}.append({_msg})
+  if {_sorted} is "challenge":
+    set {_prefix} to "&l"
+  else:
+    set {_prefix} to "&r"
+  set {_msg} to newTextComponent(getlang("islandtoplist_challenge",{_lang},{_prefix}))
+  set {_msg} to setclickcmdevent({_msg},"/island top 1 challenge")
+  set {_msg} to sethovertextevent({_msg},getlang("islandtoplist_challenge_hover",{_lang}))
+  {_book}.append({_msg})
+  if {_sorted} is "visitors":
+    set {_prefix} to "&l"
+  else:
+    set {_prefix} to "&r"
+	
+  set {_msg} to newTextComponent(getlang("islandtoplist_visitors",{_lang},{_prefix}))
+  set {_msg} to setclickcmdevent({_msg},"/island top 1 visitors")
+  set {_msg} to sethovertextevent({_msg},getlang("islandtoplist_visitors_hover",{_lang}))
+  {_book}.append({_msg})
+  set {_msg} to overwritecomponentevents(newTextComponent(" %nl%"))
+  {_book}.append({_msg})
   #
   # > Loop through the toplist site, the player has requested.
   loop {_top::%{_pageint}%::*}:
@@ -144,13 +199,19 @@ function islandtoplist(p:player,pageint:text,gui:boolean=false):
     # > Replace the name placeholder with the rank holder.
     replace all "<name>" with "%{_lp}%" in {_rank}
     set {_msg} to newTextComponent("%{_rank}%%nl%")
-    set {_msg} to setclickcmdevent({_msg},"/island info %{_lp}% island top %{_pageint}%")
+    set {_msg} to setclickcmdevent({_msg},"/island info %{_lp}% island top %{_pageint}% %{_sorted}%")
     #
     # > Prepare and set the on hover event text for the toplist.
     set {_hovertext} to getlang("toplistbookhover",{_lang})
     replace all "<name>" with "%{_lp}%" in {_hovertext}
     replace all "<rank>" with loop-index in {_hovertext}
-    replace all "<level>" with "%{_level::%loop-value%}%" in {_hovertext}
+    replace all "<level>" with "%{SB::islvl::%loop-value%}%" in {_hovertext}
+    replace all "<challengexp>" with "%{SB::island::%loop-value%::challengexp}%" in {_hovertext}
+    if {SB::visits::%loop-value%} is not set:
+      set {_visits} to 0
+    else:
+      set {_visits} to {SB::visits::%loop-value%}
+    replace all "<visitors>" with "%{_visits}%" in {_hovertext}
     set {_msg} to sethovertextevent({_msg},{_hovertext})
     {_book}.append({_msg})
   #

--- a/SkyBlock/SKYBLOCK.SK/Functions/warphandler.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/warphandler.sk
@@ -56,13 +56,20 @@ function warphandler(p:player,action:text,arg1:text="1",arg2:text="1"):
 		# > Prevent increasing visits through warping to own warps.
         if {_p} is not {_target}:
           #
-          # > Add 1 to the visits counter of the island.
-          add 1 to {SB::visits::%{_x}%_%{_y}%_%{_z}%}
+          # > Count only once per server session for each unique user.
+          if metadata value "sb-visited-%{_x}%_%{_y}%_%{_z}%" of {_p} is not set:
+            #
+            # > Add 1 to the visits counter of the island.
+            add 1 to {SB::visits::%{_x}%_%{_y}%_%{_z}%}
+            #
+            # > Set a metadata value to prevent counting one user multiple times.
+            set metadata value "sb-visited-%{_x}%_%{_y}%_%{_z}%" of {_p} to true
       else:
         #
-        # > There is no warp, print error message.
+        # > There is no such warp, print error message and open warp toplist.
         set {_msg} to getlang("warpnotfound",{_lang})
         message "%{_prefix}% %{_msg}%" to {_p}
+        islandtoplist({_p},"1",false,"visitors")
     else:
       #
       # > There is no such player, print error message.
@@ -146,42 +153,8 @@ import:
 # > Arguments:
 # > <player>player, <text>site
 # > Actions:
-# > The warptoplist prints a toplist of the most visited warps to the player.
+# > The warptoplist callse the islandtoplist function to open a toplist sorted by visitors.
 function warptoplist(p:player,site:text):
   #
-  # > Get the uuid of the player, the current language code and also the chat prefix:
-  set {_uuid} to uuid of {_p}
-  set {_lang} to getlangcode({_p})
-  set {_prefix} to getlang("prefix",{_lang})
-  #
-  # > Get the current site which should be displayed.
-  set {_site} to {_site} parsed as number
-  if {_site} is not set:
-    set {_site} to 1
-  #
-  # > Sort the visits variable using the Java utility Arrays.
-  Arrays.sort({SB::visits::*})
-  #
-  # > Send header of the toplist to the player
-  set {_msg} to getlang("warptop",{_lang})
-  message "%{_prefix}% %{_msg}%" to {_p}
-  #
-  # > If the site is not 1, multiply it by 10 to make it compatible to the loop.
-  set {_rankdisplay} to 1
-  if {_site} is not 1:
-    set {_rankdisplay} to {_site} * 10
-  #
-  # > Loop through the toplist and display the right site.
-  loop {SB::visits::*}:
-    add 1 to {_rank}
-    if {_rank} >= {_rankdisplay}:
-      if {_rank} <= {_rankdisplay}+10:
-        set {_msg} to getlang("warptoplist",{_lang})
-        replace all "<rank>" with "%{_rank}%" in {_msg}
-        replace all "<leader>" with "%{SB::island::%loop-index%::leader} parsed as offline player%" in {_msg}
-        replace all "<visits>" with "%loop-value%" in {_msg}
-        message "%{_prefix}% %{_msg}%" to {_p}
-  #
-  # > Help the player on how to visit an island.
-  set {_msg} to getlang("warptoisland",{_lang})
-  message "%{_prefix}% %{_msg}%" to {_p}
+  # > Call the island toplist sorted by visitors.
+  islandtoplist({_p},{_site},false,"visitors")

--- a/SkyBlock/lang/de.yml
+++ b/SkyBlock/lang/de.yml
@@ -197,7 +197,14 @@ language:
   # > /island top
 - istopheader: "&eTop 10 &6&l(<currentpage>/<allpages>)"
 - istoplist: "&7&l<rank>&8 | &8<name>"
-- toplistbookhover: "<name><nl1><guispacer><nl1>&r&7Rang: <rank><nl1>Insellevel: <level><nl1><guispacer>"
+- toplistbookhover: "<name><nl1><guispacer><nl1>&r&7Rang: <rank><nl1>Insellevel: <level><nl1>Erfahrung durch<nl1>Herausforderungen: <challengexp><nl1>Besucher: <visitors><nl1><guispacer>"
+- islandtoplist_sortby: "Sortierung: "
+- islandtoplist_island: "[L]"
+- islandtoplist_challenge: " [C] "
+- islandtoplist_visitors: "[B]"
+- islandtoplist_island_hover: "Sortierung nach Insellevel<nl1><s1>Zeigt die Bestenliste<nl1>sortiert nach dem<nl1>Insellevel an."
+- islandtoplist_challenge_hover: "Sortierung nach Herausforderungen<nl1><s1>Zeigt die Bestenliste<nl1>sortiert nach der<nl1>Herausforderungserfahrung an."
+- islandtoplist_visitors_hover: "Sortierung nach Besuchern<nl1><s1>Zeigt die Bestenliste<nl1>sortiert nach den<nl1>Besuchern an."
 
   #
   # > /isadmin - command feedback
@@ -251,7 +258,7 @@ language:
   
   #
   # > Chat headers
-- topheader: "&lBestenliste (<start>/<end>"
+- topheader: "&lBestenliste"
 - levelheader: <p2>Insel Level <s1>&l- <p1>
 - votereward: "&bVote für Belohnungen: "
 - rewardwoods: <p1>Holzkiste


### PR DESCRIPTION
This pull request aims to make the `/island top` list sortable and also replace the `/is warp top` toplist.



Close https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/255.
Close https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/259.


- [x] Added sortable toplists
- [x] Prevent multiple visitor counter increases by one user per server session
- [x] No loading errors
- [x] Works as expected