### PR TITLE
Added deathback add-on

### DIFF
--- a/SkyBlock/addons/deathback.sk
+++ b/SkyBlock/addons/deathback.sk
@@ -1,0 +1,38 @@
+#
+# ==============
+# deathback.sk v0.0.1
+# ==============
+# Allows players to get back to their death position.
+# ==============
+# Dependencies
+# ==============
+# > Spigot - https://hub.spigotmc.org/jenkins/job/BuildTools/
+# > Skript by bensku - https://github.com/SkriptLang/Skript/releases
+# ==============
+# How to use it:
+# ==============
+# > This script doesn't need any setup on server side.
+# > Put this file into the scripts folder of Skript and reload.
+
+#
+# > Event - on death of player
+# > Actions:
+# > If a player dies, set the death location to metadata of the player
+# > to get it later. Also send a message that explains that there is a
+# > /back command.
+on death of player:
+  set metadata value "deathback-location" of victim to location of victim
+  message getlang("deathback_backcmd",{_lang},getlang("prefix",{_lang},""," ")) to victim
+
+#
+# > Command - /back
+# > Actions:
+# > Teleports the player back to his death location, if one is set.
+command /back:
+  trigger:
+    set {_lang} to getlangcode(player)
+    if metadata value "deathback-location" of player is set:
+      teleport player to metadata value "deathback-location" of player
+      message getlang("deathback_teleported",{_lang},getlang("prefix",{_lang},""," "))
+    else:
+      message getlang("deathback_nolocation",{_lang},getlang("prefix",{_lang},""," "))

--- a/SkyBlock/lang/de.yml
+++ b/SkyBlock/lang/de.yml
@@ -457,10 +457,16 @@ language:
 
   #
   # > Anti AFK
-- antiafk_showactivity: "Aktivität wird nun angezeigt."
-- antiafk_hideactivity: "Aktivität wird nun ausgeblendet."
-- antiafk_kickreason: "Du hast dich zu lange nicht bewegt. Bewege dich mehr, damit deine Aktivität steigt."
-- antiafk_actionbar: "Aktivität: <activity>"
+- antiafk_showactivity: "<s1>Aktivität wird nun angezeigt."
+- antiafk_hideactivity: "<s1>Aktivität wird nun ausgeblendet."
+- antiafk_kickreason: "<s1>Du hast dich zu lange nicht bewegt. Bewege dich mehr, damit deine Aktivität steigt."
+- antiafk_actionbar: "<s1>Aktivität: <activity>"
+
+  #
+  # > Deathback
+- deathback_nolocation: "<s1>Dieser Befehl funktioniert nur nachdem du gestorben bist."
+- deathback_backcmd: "<s1>Du kannst zu dem Todesort mit <p1>/back<s1> zurückkehren."
+- deathback_teleported: "<s1>Du wurdest zu deinem Todesort teleportiert."
 
   #
   # > Votingrewards


### PR DESCRIPTION
Aims to add a command which allows the player to get back to the death location using `/back`.

- [x] Works as expected
- [x] Loads without errors

Close https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/269 once merged.