### PR TITLE
Added functions for adding new recipes

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Functions/registerrecipe.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/registerrecipe.sk
@@ -1,0 +1,83 @@
+#
+# ==============
+# registerrecipe.sk
+# ==============
+# registerrecipe.sk is part of the SKYBLOCK.SK functions.
+# ==============
+
+import:
+  org.bukkit.Material
+  org.bukkit.inventory.ItemStack
+  org.bukkit.inventory.ShapedRecipe
+  org.bukkit.inventory.ShapelessRecipe
+  org.bukkit.Bukkit
+  org.bukkit.NamespacedKey
+
+#
+# > Function - addShapedRecipe:
+# > Parameters:
+# > <item> result item
+# > <item> ingredient 1
+# > <item> ingredient 2
+# > <item> ingredient 3
+# > <item> ingredient 4
+# > <item> ingredient 5
+# > <item> ingredient 6
+# > <item> ingredient 7
+# > <item> ingredient 8
+# > <item> ingredient 9
+# > Actions:
+# > Creates a shaped recipe, which can be used by players.
+# > The shape is set up like this:
+# > 1 | 2 | 3
+# > 4 | 5 | 6
+# > 7 | 8 | 9
+# > If a ingredient should be left empty, use air.
+function addShapedRecipe(result:item,i1:item=air,i2:item=air,i3:item=air,i4:item=air,i5:item=air,i6:item=air,i7:item=air,i8:item=air,i9:item=air):
+  #
+  # Create a new shaped recipe of the result item with the NameSpacedKey of Skript with the key "registerrecipe".
+  set {_key} to "%{_result}%-%{_i1}%-%{_i2}%-%{_i3}%-%{_i4}%-%{_i5}%-%{_i6}%-%{_i7}%-%{_i8}%-%{_i9}%"
+  replace all " " with "" in {_key}
+  set {_recipe} to new ShapedRecipe(new NamespacedKey(Bukkit.getServer().getPluginManager().getPlugin("Skript"), "registerrecipe-%{_key}%"), 1 of {_result})
+  #
+  # > Create a shape for the recipe.
+  {_recipe}.shape("123","456","789")
+  #
+  # > Loop through all ingredients and add them.
+  loop 9 times:
+    {_recipe}.setIngredient("%loop-number%", {_i%loop-number%}.getType())
+  #
+  # > Add the recipe. This a exception will happen if the recipe is added multiple times,
+  # > it will not overwrite the recipe, restart if necessary.
+  Bukkit.addRecipe({_recipe})
+
+#
+# > Function - addShapelessRecipe:
+# > Parameters:
+# > <item> result item
+# > <item> ingredient 1
+# > <item> ingredient 2
+# > <item> ingredient 3
+# > <item> ingredient 4
+# > <item> ingredient 5
+# > <item> ingredient 6
+# > <item> ingredient 7
+# > <item> ingredient 8
+# > <item> ingredient 9
+# > Actions:
+# > Creates a shapedless recipe, which can be used by players.
+function addShapelessRecipe(result:item,i1:item=air,i2:item=air,i3:item=air,i4:item=air,i5:item=air,i6:item=air,i7:item=air,i8:item=air,i9:item=air):
+  #
+  # Create a new shapedless recipe of the result item with the NameSpacedKey of Skript with the key "registerrecipe".
+  set {_key} to "%{_result}%-%{_i1}%-%{_i2}%-%{_i3}%-%{_i4}%-%{_i5}%-%{_i6}%-%{_i7}%-%{_i8}%-%{_i9}%"
+  replace all " " with "" in {_key}
+  set {_recipe} to new ShapelessRecipe(new NamespacedKey(Bukkit.getServer().getPluginManager().getPlugin("Skript"), "registerrecipe-%{_key}%"), 1 of {_result})
+  #
+  # > Loop through all ingredients and add them to the recipe.
+  loop 9 times:
+    if {_i%loop-number%} is not air:
+      {_recipe}.addIngredient({_i%loop-number%}.getAmount(), {_i%loop-number%}.getType())
+  #
+  # > Add the recipe. This a exception will happen if the recipe is added multiple times,
+  # > it will not overwrite the recipe, restart if necessary.
+  Bukkit.addRecipe({_recipe})


### PR DESCRIPTION
This pull request is going to add functions which allow to register recipes which then can be crafted by players. This replaces the SkQuery recipe register function, which is deprecated.

- [ ] Working as expected
- [ ] Loading without errors.

Close https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/281 once merged.