### PR TITLE
Prevent exeeding the maximum sell limit with mass selling

### DIFF
--- a/SkyBlock/addons/store.sk
+++ b/SkyBlock/addons/store.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# store.sk v0.0.7
+# store.sk v0.0.8
 # ==============
 # Allow your players to buy and sell stuff easily.
 # ==============
@@ -858,24 +858,50 @@ function storeshophandler(player:player,action:text,shop:text,itemshopid:number,
         # > Get the amount of the current ItemStack.
         set {_number} to "%{_item}.getAmount()%" parsed as number
         #
-        # > Divide the pricce with the amount of the ItemStack, that way, we get
+        # > Divide the price with the amount of the ItemStack, that way, we get
         # > the price of 1 piece.
         set {_price} to {_price} / {_number}
         #
-        # > Multiply the price for one piece with all pieces of the item the player
-        # > has in his inventory.
-        set {_price} to {_price} * number of {_item} in {_player}'s inventory
+        # > Check if the bulk sell is higher than the allowed selllimit and limit it.
+        set {_maxamount} to number of {_item} in {_player}'s inventory
+        delete {_totalprice}
+        delete {_totalamount}
+        #
+        # > Check if the total price exeeds the sell limit for this player for this server session.
+        # > If it does, only sell the amount which doesn't exeed the sell limit.
+        while {_done} is not set:
+          add {_price} to {_totalprice}
+          add 1 to {_totalamount}
+          #
+          # > Reached the maximum amount, stop here.
+          if {_totalamount} is {_maxamount}:
+            set {_done} to true
+          #
+          # > The total amount got somehow higher than the maximum amount,
+          # > this should never happen but better be safe.
+          else if {_totalamount} > {_maxamount}:
+            set {_totalamount} to {_maxamount}
+          #
+          # > If the sell limit has been exeeded, remove the added price and amount 
+          # > from above again and stop this while loop.
+          if (metadata value "store-sells-serversession" of {_player} + {_totalprice}) > getconfigobject("store-selllimit"):
+            remove {_price} from {_totalprice}
+            remove 1 from {_totalamount}
+            set {_done} to true
+        #
+        # > Set the final price which should be given to the player.
+        set {_price} to {_totalprice}
         #
         # > Create new Text Components to send them to the player. Also sends an
         # > TranslatableComponent, which is going to be translated by the client.
         set {_langmsg::*} to getlang("store_soldxitems",{_lang}) split at "<ph>"
-        set {_msg} to newTextComponent("%{_prefix}% %{_langmsg::1}%%number of {_item} in {_player}'s inventory% %{_langmsg::2}%")
+        set {_msg} to newTextComponent("%{_prefix}% %{_langmsg::1}%%{_totalamount}% %{_langmsg::2}%")
         {_msg}.addExtra(getTranslatableComponentFromItem({_item}))
         {_msg}.addExtra(newTextComponent("%{_langmsg::3}%%{_price}% %{_currency}%%{_langmsg::4}%"))
         {_player}.sendMessage({_msg})
         #
-        # > Remove all the defined items and give the player the calculated money. Then stop.
-        remove number of {_item} in {_player}'s inventory of {_item} from {_player}'s inventory 
+        # > Remove the calculated amount of items and give the player the calculated money. Then stop.
+        remove {_totalamount} of {_item} from {_player}'s inventory 
         add {_price} to {_player}'s balance
         #
         # > Add the money to a temporary metadata storage to limit sells per player.


### PR DESCRIPTION
Now, only the maximum amount of items can be sold using mass selling within the `/store`. If it exeeds, the maximum amount until the sell limit is hit is being sold.

Before, people were able to exeed the daily limit by making a bulk sell order for a valuable item.

- [x] Works as expected
- [x] Loads without errors


Close https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/291 once merged.