### PR TITLE
Added water bubble streams to antiafk.sk

### DIFF
--- a/SkyBlock/addons/antiafk.sk
+++ b/SkyBlock/addons/antiafk.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# antiafk.sk v0.0.2
+# antiafk.sk v0.0.3
 # ==============
 # Prevents players from being afk, active players are granted to stand a while afk, if they
 # have been active before being afk.
@@ -159,9 +159,17 @@ function antiafk():
           #
           # > If the player is within water or riding, only the view of the player is checked,
           # > since the player could go afk in water or while riding.
-          if block at loop-value is water:
+          set {_tmpblock} to block at loop-value
+          set {_tmpbelowblock} to block 1 below loop-value
+          if {_tmpblock} is water:
             set {_checkview} to true
-          if loop-value is riding:
+          #
+          # > Prevent being afk on a water bubble stream.
+          else if {_tmpblock} is upward bubble column:
+            set {_checkview} to true
+          else if {_tmpbelowblock} is upward bubble column:
+            set {_checkview} to true
+          else if loop-value is riding:
             set {_checkview} to true
           #
           # > If the player isn't in water or riding, increase the activity.


### PR DESCRIPTION
This pull request adds a way to prevent players from being afk on water bubble streams.

- [x] Works as expected
- [x] Loads without errors

Close https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/288 once merged.