### PR TITLE
Added snow and ice block melting flag event

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Events.sk
+++ b/SkyBlock/SKYBLOCK.SK/Events.sk
@@ -36,6 +36,13 @@ on despawn of any fish:
     cancel event
 
 #
+# > Event - on fade of snow or ice
+# > Actions:
+# > If snow or ice melts, it is checked if the event should be cancelled or not.
+on fade of snow block or ice block:
+  handlegeneralflagevent(event,false,event-location,"snow-ice-melt")
+
+#
 # > Event - rightclick
 # > If a player rightclicks, this event is triggered
 # > Actions:
@@ -617,17 +624,17 @@ on quit:
   # > If custom quit messages are enabled,
   # > send custom ones.
   if {SB::config::customjoinquit} is true:
-  #
-  # > Disable the global leave message by setting it to a text
-  # > with a length of 0.
-  set quit message to ""
-  #
-  # > Send a translated join message to every player.
-  loop all players:
-    set {_msg} to getlang("prefix",getlangcode(loop-player),"",getlang("quitmessage",getlangcode(loop-player)," "))
-    replace all "<player>" with "%player%" in {_msg}
-    message {_msg} to loop-player
-  delete {_msg}
+    #
+    # > Disable the global leave message by setting it to a text
+    # > with a length of 0.
+    set quit message to ""
+    #
+    # > Send a translated join message to every player.
+    loop all players:
+      set {_msg} to getlang("prefix",getlangcode(loop-player),"",getlang("quitmessage",getlangcode(loop-player)," "))
+      replace all "<player>" with "%player%" in {_msg}
+      message {_msg} to loop-player
+    delete {_msg}
 
 #
 # > Event - on connect

--- a/SkyBlock/config/flags.yml
+++ b/SkyBlock/config/flags.yml
@@ -252,6 +252,10 @@ defaultislandflags-general:
 # > Tree branches. True = enabled, false = disabled.
 - tree-branches: true
 - toggle-tree-branches: true
+#
+# > Snow and ice melting. True = enabled, false = disabled.
+- snow-ice-melt: true
+- toggle-snow-ice-melt: true
 
 #
 # > Flags for not inhabited islands:

--- a/SkyBlock/lang/de.yml
+++ b/SkyBlock/lang/de.yml
@@ -311,6 +311,7 @@ language:
 - flag_pvpt: "&rSpieler gegen Spieler"
 - flag_slime-spawningt: "Schleim"
 - flag_tree-branchest: "Verästelte Bäume"
+- flag_snow-ice-meltt: "Schnee- und Eisschmelze"
 - flag_flagst: "Flags"
 - flag_generalt: "Allgemeine Flags"
 - flag_foreignt: "Flags für Fremde"
@@ -342,6 +343,7 @@ language:
 - flag_pvpd: "<s1>Erlaubt Spieler gegen<nl><s1>Spieler auf deiner Insel."
 - flag_slime-spawningd: "<s1>Erlaubt das erscheinen<nl><s1>von Schleim auf<nl><s1>deiner Insel."
 - flag_tree-branchesd: "<s1>Erlaubt verästelten Bäumen<nl><s1>auf deiner Insel zu wachsen."
+- flag_snow-ice-meltd: "<s1>Lässt Schnee und Eis bei<nl><s1>warmen Temperaturen<nl><s1>auf deiner Insel schmelzen."
 - flag_generald: "<s1>Verändere hier Einstellungen,<nl><s1>die deine Insel allgemein<nl><s1>betreffen."
 - flag_foreignd: <s1>Erlaube Fremden diverse<nl><s1>Aktionen auf deiner Insel<nl><s1>auszuführen, ändere<nl><s1>diese Einstellungen hier.
 - flag_trustedd: <s1>Erlaube Vertrauten diverse<nl><s1>Aktionen auf deiner Insel<nl><s1>auszuführen, ändere<nl><s1>diese Einstellungen hier.


### PR DESCRIPTION
Adds a flag which allows the player to change the flag for snow and ice melting if the island isn't a snowy region.

- [x] Works as expected
- [x] Loads without errors

Close https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/289 once merged.