### PR TITLE
Added mob lists and limitation per island

### DIFF
--- a/SkyBlock/SKYBLOCK.SK/Commands.sk
+++ b/SkyBlock/SKYBLOCK.SK/Commands.sk
@@ -299,9 +299,18 @@ command /island [<text>] [<text=1>] [<text>]:
     # > Argument: "info" ("level" or "lvl")
     # > If a player types in /island info, islandinfo function is called.
     # > Actions:
-    # > Calls the islandinfo function with the player and second argument as parameter.
+    # > Calls the islandinfo function with the player, second argument 
+    # > as parameter (target player) and a third as back link command.
     else if arg-1 is "info" or "level" or "lvl":
       islandinfo(player,arg-2,arg-3)
+    #
+    # > Argument: "entity" or "entities"
+    # > If a player types in /island entity, islandentityinfo function is called.
+    # > Actions:
+    # > Calls the islandentityinfo function with the player, second argument
+    # > as parameter (target player) and a third as back link command.
+    else if arg-1 is "entity" or "entities":
+      islandentityinfo(player,arg-2,arg-3)
     #
     # > Argument: "generator" ("gen" OR "oregen" OR "oregenerator")
     # > If a player types in /island generator, his current generator level is displayed

--- a/SkyBlock/SKYBLOCK.SK/Events.sk
+++ b/SkyBlock/SKYBLOCK.SK/Events.sk
@@ -14,6 +14,8 @@ import:
   org.bukkit.event.player.PlayerInteractEntityEvent
   org.bukkit.event.hanging.HangingBreakByEntityEvent
   org.bukkit.event.world.StructureGrowEvent
+  org.bukkit.event.player.PlayerTeleportEvent
+
 #
 # > Event - PlayerArmorStandManipulateEvent
 # > If someone tries to change a armor stand.
@@ -647,15 +649,16 @@ on connect:
       set {_prefix} to getlang("prefix",getlangcode(player))
       set {_msg} to getlang("delismsg",getlangcode(player))
       kick player due to "%{_prefix}% %{_msg}%"
+
 #
-# > Event - teleport
+# > Event - PlayerTeleportEvent
 # > Triggered on a teleportation
 # > Actions:
 # > If the teleported entity is a player and the teleport cause is a nether portal, check
 # > through settings if this is allowed or not.
-on teleport:
-  if event-entity is a player:
-    if "%teleport cause%" is "nether portal":
+on PlayerTeleportEvent:
+  if event.getPlayer() is a player:
+    if "%event.getCause()%" is "nether portal":
       #
       # > If no special non-vanilla effect should happen, stop this skript here.
       if {SB::config::nether} is false:
@@ -668,7 +671,7 @@ on teleport:
       #
       # > Cancel the event if the nether is enabled
       cancel event
-      set {_p} to event-entity
+      set {_p} to event.getPlayer()
       #
       # > Check the location of the opposite world (nether|world) for a portal.
       set {_l} to location of {_p}
@@ -690,13 +693,14 @@ on teleport:
       #
       # > Teleport the player to the other world (nether|world).
       teleport {_p} to {_newloc}
+      set {_uuid} to uuid of {_p}
       #
       # > If the player has an island and the island block of the player has no
       # > bedrock in the nether yet, it is going to be set.
-      if {SB::player::%uuid of player%::island::bedrock} is set:
-        set {_x} to x-coord of {SB::player::%uuid of player%::island::bedrock}
-        set {_y} to y-coord of {SB::player::%uuid of player%::island::bedrock}
-        set {_z} to z-coord of {SB::player::%uuid of player%::island::bedrock}
+      if {SB::player::%{_uuid}%::island::bedrock} is set:
+        set {_x} to x-coord of {SB::player::%{_uuid}%::island::bedrock}
+        set {_y} to y-coord of {SB::player::%{_uuid}%::island::bedrock}
+        set {_z} to z-coord of {SB::player::%{_uuid}%::island::bedrock}
         set {_netherbedrock} to location at {_x}, {_y}, {_z} in "%{_target}%" parsed as world
         if block at {_netherbedrock} is not bedrock:
           set block at {_netherbedrock} to bedrock

--- a/SkyBlock/SKYBLOCK.SK/Functions/entitylimit.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/entitylimit.sk
@@ -1,0 +1,79 @@
+#
+# ==============
+# entitylimit.sk v0.0.1
+# ==============
+# entitylimit.sk is part of SKYBLOCK.SK.
+# ==============
+# > This file will load events and functions to prevent exeeding the
+# > predefined entity limit. It also supports island upgrades.
+# > Please do not disable this file, as it is no add-on and needed.
+# ==============
+# Dependencies
+# ==============
+# > Spigot 1.13.2 - https://hub.spigotmc.org/jenkins/job/BuildTools/
+# > Skript by bensku - https://github.com/SkriptLang/Skript/releases
+# > skript-mirror - https://github.com/btk5h/skript-mirror/releases
+# ==============
+
+#
+# > Event - on spawn of a living entity
+# > Triggered every time, a living entity is spawned.
+# > Actions:
+# > Checks, if the limit has been reached, if it has been reached,
+# > cancel the event.
+on spawn of a living entity:
+  if checkEntityLimitReached(event-location) is true:
+    cancel event
+
+#
+# > Event - on rightclick holding any spawn egg or armor stand or any minecart or any boat
+# > Triggered when the player rightclicks with the specified items.
+# > Actions:
+# > Checks, if the limit has been reached, if it has been reached,
+# > cancel the event and tell the player about it.
+on rightclick holding any spawn egg or armor stand or any minecart or any boat:
+  if checkEntityLimitReached(event-location) is true:
+    message getlang("prefix",getlangcode(player),"",getlang("entitylimitreached",getlangcode(player)," "))
+    cancel event
+
+#
+# > Event - on spawn of a living entity
+# > Triggered if a painting or item frame is placed.
+# > Actions:
+# > Checks, if the limit has been reached, if it has been reached,
+# > cancel the event and tell the player about it.
+on place of a painting or item frame:
+  if checkEntityLimitReached(event-location) is true:
+    message getlang("prefix",getlangcode(player),"",getlang("entitylimitreached",getlangcode(player)," "))
+    cancel event
+
+#
+# > Function - checkEntityLimitReached
+# > Parameters:
+# > <location>a location where it should be checked if a limit has been reached
+# > Actions:
+# > Checks if the entity limit has been reached or exeeded and return true in that case.
+function checkEntityLimitReached(loc:location) :: boolean:
+  set {_bedrock} to getcurrentbedrockmain({_loc})
+  if getIslandEntityAmount({_bedrock}) > getIslandEntityLimit({_bedrock}):
+    return true
+  return false
+
+#
+# > Function - getIslandEntityLimit
+# > Parameters:
+# > <location>the location of a island bedrock
+# > Actions:
+# > Gets the current island entity limit by looking up the current
+# > configuration for island upgrades and check the island upgrade
+# > level.
+function getIslandEntityLimit(loc:location) :: number:
+  #
+  # > This function is not going to be finished in this pull request.
+  # > Later on, there will be a new pull request with a updated
+  # > island upgrade menu, which (pretty sure) also comes with a
+  # > function which allows to get the current upgrade level and
+  # > the limits to it to reduce work. The comment in the first lines
+  # > that state that this file is compatible with the island upgrades
+  # > is false for now but will change in the upcoming versions.
+  return 5000

--- a/SkyBlock/SKYBLOCK.SK/Functions/islandinfo.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/islandinfo.sk
@@ -132,9 +132,7 @@ function islandinfo(p2:player,p:text="1",previousmenu:text="none"):
   {_book}.append(newTextComponent("[%{_homelevel}%/5] %getlang(""bc_islandhometitle"",{_lang})%%nl%"))
   {_book}.append(newTextComponent("[%{_hopperlevel}%/5] %getlang(""bc_islandhoppertitle"",{_lang})%%nl%"))
   {_book}.append(newTextComponent("[%{_sizelevel}%/5] %getlang(""bc_islandsizetitle"",{_lang})%"))
-
   {_book}.append(newTextComponent("%nl%-------------------%nl%"))
-
   #
   # > Go back to previous menu link:
   if {_previousmenu} is set:
@@ -159,6 +157,23 @@ function islandinfo(p2:player,p:text="1",previousmenu:text="none"):
   {_book}.append(newTextComponent("%nl%-------------------%nl%"))
   {_book}.append(newTextComponent("%getlang(""activehoppers"",{_lang})% %{_activehoppers}%"))
   {_book}.append(newTextComponent("%nl%-------------------%nl%"))
+  set {_msg} to newTextComponent("%getlang(""activeentites"",{_lang})% %getIslandEntityAmount({_bedrock})%")
+  set {_lore} to getlang("info_activentitieslore",{_lang})
+  set {_head} to getlang("info_activentitiestitle",{_lang})
+  set {_msg} to sethovertextevent({_msg},"%{_head}%%nl%%{_lore}%")
+  #
+  # > If a previous menu exists and it isn't "none", add it to the back command.
+  if {_previousmenu} is set:
+    if {_previousmenu} is not "none":
+      set {_msg} to setclickcmdevent({_msg},"/is entity %{_uuid}% is info %{_uuid}% %{_previousmenu}%")
+  #
+  # > If there is no previous menu to this, add no previous menu.
+  else:
+    set {_msg} to setclickcmdevent({_msg},"/is entity %{_uuid}% is info %{_uuid}%")
+  {_book}.append({_msg})
+  set {_msg} to newTextComponent("%nl%-------------------%nl%")
+  set {_msg} to overwritecomponentevents({_msg})
+  {_book}.append({_msg})
   #
   # > Create the book site with the ComponentBuilder and add it to the sites.
   add {_book}.create() to {_sites::*}
@@ -181,3 +196,144 @@ function islandinfo(p2:player,p:text="1",previousmenu:text="none"):
   set {_p2}'s tool to {_item}
   openbook({_p2})
   set {_p2}'s tool to {_tool}
+
+#
+# > Function - islandentityinfo
+# > Parameters:
+# > <player>the player who wants to get the information
+# > <text>the owner of the island as text
+# > <text>a command which leads to the previous menu (optional)
+# > Actions:
+# > Opens a list of all active entities within a book to the player.
+function islandentityinfo(p:player,islandplayer:text,backcmd:text=""):
+  #
+  # > Prevent client side gliches or instant close by waiting 2 ticks.
+  wait 2 ticks
+  #
+  # > Get the language of the player who wants the list.
+  set {_lang} to getlangcode({_p})
+  #
+  # > Get the island player as offline player.
+  set {_islandplayer} to {_islandplayer} parsed as offline player
+  #
+  # > If the island player is "1", set the player who wanted to open
+  # > this menu as the island player.
+  if {_islandplayer} is "1":
+    set {_islandplayer} to {_p}
+  #
+  # > If the island player is set, get the entites and open a book to the player.
+  if {_islandplayer} is set:
+    set {_uuid} to uuid of {_islandplayer}
+    #
+    # > Get the bedrock location of the player.
+    set {_bedrock} to {SB::player::%{_uuid}%::island::bedrock}
+    set {_sites::*} to getIslandEntityBookList({_bedrock},{_lang},{_backcmd})
+    createopenbook({_p},{_sites::*})
+	
+#
+# > Function - getIslandEntityBookList
+# > Parameters:
+# > <location>the location of the island bedrock
+# > Actions:
+# > Counts all entities, creates a list and returns book pages which can be
+# > opened using the createopenbook(player,sites) function.
+function getIslandEntityBookList(loc:location,lang:text,backcmd:text="none") :: objects:
+  #
+  # > Get the configured distance of the islands.
+  set {_dist} to {SB::config::distance}
+  #
+  # > Get all entities within the distance from the bedrock location.
+  set {_entities::*} to ...{_loc}.getWorld().getNearbyEntities({_loc}, {_dist}-1, 256, {_dist}-1)
+  #
+  # > Loop all entities and count them after unique entities to
+  # > create a viewable list.
+  loop {_entities::*}:
+    if loop-value is not a player or a dropped item:
+      add 1 to {_uniqueentities::%loop-value.getType()%}
+  #
+  # > Create a list within a book using the Component Builder.
+  set {_list} to newComponentBuilder()
+  #
+  # > Add a header to the book.
+  {_list}.append(newTextComponent("&lAktive Wesen%nl%%{SB::config::bookspacer}%%nl%%nl%"))
+  #
+  # > These variables are there to determine if the first site has been done or still has to
+  # > be created, this is important for the back link arrow on the first page.
+  set {_endcreate} to 1
+  set {_firstsite} to true
+  #
+  # > Loop all unique entities and add them to the book.
+  loop {_uniqueentities::*}:
+    add 1 to {_pageline}
+    set {_endcreate} to 1
+    {_list}.append(getTranslatableComponentFromEntityType(loop-index))
+    {_list}.append(newTextComponent(": %loop-value%%nl%"))
+    if {_pageline} is 9:
+      delete {_pageline}
+      delete {_endcreate}
+      #
+      # > The first site gets a special "back" link to get to the previous menu.
+      if {_firstsite} is true:
+        if {_backcmd} is not "none":
+          #
+          # > Add a new line before the back link gets added.
+          {_list}.append(" %nl%")
+          {_list}.append(createbookbacklinkentityinfo({_backcmd},{_lang}))
+          delete {_firstsite}
+      add {_list}.create() to {_sites::*}
+      set {_list} to newComponentBuilder()
+      {_list}.append(newTextComponent("&lAktive Wesen%nl%%{SB::config::bookspacer}%%nl%%nl%"))
+  #
+  # > If there haven't been exactly 9 lines for the last page, this
+  # > part is going to create the last page.
+  if {_endcreate} is set:
+    #
+	# > If there are less than 9 lines, we also have to create the first page here.
+    if {_firstsite} is true:
+      if {_backcmd} is not "none":
+        #
+        # > Add a new line before the back link gets added.
+        {_list}.append(" %nl%")
+        {_list}.append(createbookbacklinkentityinfo({_backcmd},{_lang}))
+    add {_list}.create() to {_sites::*}
+  #
+  # > Return all book pages, which contains entity information.
+  return {_sites::*}
+
+#
+# > Function - createbookbacklinkentityinfo
+# > Parameters:
+# > <text>the command which should be executed if the player clicks on the link
+# > Actions:
+# > Creates a message with a clickable link, which executes a command.
+function createbookbacklinkentityinfo(backcmd:text,lang:text) :: object:
+  set {_msg} to newTextComponent("&l←&r")
+  set {_lore} to getlang("store_pagebackwardlore",{_lang})
+  set {_head} to getlang("store_pagebackward",{_lang})
+  set {_msg} to sethovertextevent({_msg},"%{_head}%%nl%%{_lore}%")
+  set {_msg} to setclickcmdevent({_msg},"/%{_backcmd}%")
+  return {_msg}
+
+#
+# > Function - getIslandEntityAmount
+# > Parameters:
+# > <location>the bedrock location of the island
+# > Actions:
+# > Counts all valid entities of the island and returns as a number.
+function getIslandEntityAmount(loc:location) :: number:
+  #
+  # > Get the distance for islands from the configuration.
+  set {_dist} to {SB::config::distance}
+  #
+  # > Get the entities within the island area.
+  set {_entities::*} to ...{_loc}.getWorld().getNearbyEntities({_loc}, {_dist}-1, 256, {_dist}-1)
+  #
+  # > Loop all entities and increase a counter for all entities that aren't players or items.
+  loop {_entities::*}:
+    if loop-value is not a player or a dropped item:
+      add 1 to {_entities}
+  #
+  # > If there aren't any entities, return 0.
+  if {_entities} is not set:
+    return 0
+  return {_entities}

--- a/SkyBlock/SKYBLOCK.SK/Functions/openbook.sk
+++ b/SkyBlock/SKYBLOCK.SK/Functions/openbook.sk
@@ -1,6 +1,6 @@
 #
 # ==============
-# openbook.sk v0.0.9
+# openbook.sk v0.0.10
 # ==============
 # Opens a book from the server side on the client.
 # ==============
@@ -163,6 +163,15 @@ function getTranslatableComponentFromItem(item:item) :: object:
   else:
     set {_vname} to "item.%{_vname}%"
   return new TranslatableComponent({_vname})
+
+#
+# > Function - getTranslatableComponentFromEntityType
+# > Parameters:
+# > <text>the entity type which should be a translatable component
+# > Actions:
+# > Converts the entity type to a TranslatableComponent and returns it.
+function getTranslatableComponentFromEntityType(type:text) :: object:
+  return new TranslatableComponent("entity.minecraft.%{_type}%")
 
 #
 # > Function - newTextComponent

--- a/SkyBlock/lang/de.yml
+++ b/SkyBlock/lang/de.yml
@@ -101,6 +101,9 @@ language:
 - isupgrades: "Inselverbesserungen:"
 - isinfonotfound: Insel konnte nicht gefunden werden.
 - activehoppers: "Aktive Trichter:"
+- activeentites: "Aktive Wesen:"
+- info_activentitiestitle: "Aktive Wesen der Insel"
+- info_activentitieslore: "<s1>Klicke Hier, um eine<nl><s1>genaue Liste aller gerade<nl><s1>aktiven Wesen der<nl><s1>Insel zu erhalten."
 
   #
   # > /island trust:

--- a/SkyBlock/lang/de.yml
+++ b/SkyBlock/lang/de.yml
@@ -391,6 +391,7 @@ language:
 - bc_islandhomeshop: Erlaubt dir insgesamt<nl><size> Homes zu setzen.
 - bc_islandupgrades: "Insel Erweiterungen"
 - upgradeavailable: "<s1>Die Insel ist nicht vollständig erweitert, erweitere die Insel, um auch hier bauen zu können: <p1>/island upgrades"
+- entitylimitreached: "<s1>Du hast die Grenze für aktive Wesen erreicht, erweitere deine Grenze mit: <p1>/island upgrades"
 
   #
   # > Island item binding


### PR DESCRIPTION
This pull request aims to add a viewable mob list into the `/island info` book and also add a limitation + a upgrade system for that which can be configured as stated below:

- The server operator can decide how many upgrades there should be. 
- The server operator can set a price to every upgrade.
- The server operator can set how the limitation should be changed per upgrade. Make it configurable how many entites are allowed on one island, which also can be increased by this.
This upgrade system has to be done in another pull request. This pull request just aims to add the `/island info` book, which contains all current entities and limit them by cancelling out mob spawning if the limit has been reached.

- [x] Mob list in `/island info` book
- [x] Mob limitation (add island upgrade functions later on)
- [x] Works as expected
- [x] Loads without errors

Close https://github.com/Abwasserrohr/SKYBLOCK.SK/issues/249 once merged.
